### PR TITLE
optional metadata

### DIFF
--- a/src/owl-core.xsl
+++ b/src/owl-core.xsl
@@ -65,37 +65,88 @@
                 <owl:imports rdf:resource="{.}"/>
             </xsl:for-each>      
              
-            <dct:title xml:lang="en">
-                <xsl:value-of select="$ontologyTitleCore"/>
-            </dct:title>
+            <xsl:if test="normalize-space($ontologyTitleCore) != ''">
+                <dct:title xml:lang="en">
+                    <xsl:value-of select="$ontologyTitleCore"/>
+                </dct:title>
+            </xsl:if>
                
-            <rdfs:label xml:lang="en">
-                 <xsl:value-of select="$ontologyLabelCore"/>
-            </rdfs:label>
+               
+            <xsl:if test="normalize-space($ontologyLabelCore) != ''">
+                <rdfs:label xml:lang="en">
+                    <xsl:value-of select="$ontologyLabelCore"/>
+                </rdfs:label>
+            </xsl:if>
             
-            <dct:description xml:lang="en">
-                <xsl:value-of select="$ontologyDescriptionCore"/>
-            </dct:description>
-            <dct:publisher>
-                <xsl:value-of select="$publisher"/>
-            </dct:publisher>
+            <xsl:if test="normalize-space($ontologyDescriptionCore) != ''">
+                <dct:description xml:lang="en">
+                    <xsl:value-of select="$ontologyDescriptionCore"/>
+                </dct:description>
+            </xsl:if>
+            <xsl:if test="normalize-space($publisher) != ''">
+                <dct:publisher>
+                    <xsl:value-of select="$publisher"/>
+                </dct:publisher>
+            </xsl:if>
+            
           <rdfs:comment>This version is automatically generated from <xsl:value-of select="tokenize(base-uri(.), '/')[last()]"/> on <xsl:value-of select="format-date(current-date(),'[Y0001]-[M01]-[D01]')"/>
               </rdfs:comment>
-            <xsl:for-each select="$seeAlsoResources">
-                <rdfs:seeAlso rdf:resource="{.}"/>
-            </xsl:for-each>
-            <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="$issuedDate"/></dct:issued>
-            <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="$createdDate"/></dct:created>
-            <owl:versionInfo><xsl:value-of select="$versionInfo"/></owl:versionInfo>   
-            <owl:incompatibleWith><xsl:value-of select="$incompatibleWith"/></owl:incompatibleWith>
-            <owl:versionIRI rdf:resource="{fn:concat($coreArtefactURI,'-',$versionInfo)}"/>
+            
+            
+            <xsl:if test="exists($seeAlsoResources)">
+                <xsl:for-each select="$seeAlsoResources">
+                    <rdfs:seeAlso rdf:resource="{.}"/>
+                </xsl:for-each>
+            </xsl:if>
+
+            
+            <xsl:if test="normalize-space($issuedDate) != ''">
+                <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
+                    <xsl:value-of select="$issuedDate"/>
+                </dct:issued>
+            </xsl:if>
+            <xsl:if test="normalize-space($createdDate) != ''">
+                <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
+                    <xsl:value-of select="$createdDate"/>
+                </dct:created>
+            </xsl:if>
+            <xsl:if test="normalize-space($versionInfo) != ''">
+                <owl:versionInfo>
+                    <xsl:value-of select="$versionInfo"/>
+                </owl:versionInfo>
+            </xsl:if>  
+            <xsl:if test="normalize-space($incompatibleWith) != ''">
+                <owl:incompatibleWith>
+                    <xsl:value-of select="$incompatibleWith"/>
+                </owl:incompatibleWith>
+            </xsl:if>
+            <xsl:if test="normalize-space($versionInfo) != ''">
+                <owl:versionIRI rdf:resource="{fn:concat($coreArtefactURI, '-', $versionInfo)}"/>
+            </xsl:if>
 <!--            <bibo:status><xsl:value-of select="$ontologyStatus"/></bibo:status>-->
             
-            <owl:priorVersion><xsl:value-of select="fn:concat($coreArtefactURI,'-',$priorVersion)"/></owl:priorVersion>
+            <xsl:if test="normalize-space($priorVersion) != ''">
+                <owl:priorVersion>
+                    <xsl:value-of select="fn:concat($coreArtefactURI, '-', $priorVersion)"/>
+                </owl:priorVersion>
+            </xsl:if>
             
-            <vann:preferredNamespaceUri><xsl:value-of select="$preferredNamespaceUri"/></vann:preferredNamespaceUri>
-            <vann:preferredNamespacePrefix><xsl:value-of select="$preferredNamespacePrefix"/></vann:preferredNamespacePrefix> 
-            <dct:license><xsl:value-of select="$licenseLiteral"/></dct:license>
+            <xsl:if test="normalize-space($preferredNamespaceUri) != ''">
+                <vann:preferredNamespaceUri>
+                    <xsl:value-of select="$preferredNamespaceUri"/>
+                </vann:preferredNamespaceUri>
+            </xsl:if>
+           
+            <xsl:if test="normalize-space($preferredNamespacePrefix) != ''">
+                <vann:preferredNamespacePrefix>
+                    <xsl:value-of select="$preferredNamespacePrefix"/>
+                </vann:preferredNamespacePrefix>
+            </xsl:if>
+            <xsl:if test="normalize-space($licenseLiteral) != ''">
+                <dct:license>
+                    <xsl:value-of select="$licenseLiteral"/>
+                </dct:license>
+            </xsl:if>
             
         </owl:Ontology>
         

--- a/src/owl-restrictions.xsl
+++ b/src/owl-restrictions.xsl
@@ -58,35 +58,94 @@
                 <owl:imports rdf:resource="{.}"/>
             </xsl:for-each>      
             <owl:imports rdf:resource="{$coreArtefactURI}"/>
-            <dct:title xml:lang="en">
-                <xsl:value-of select="$ontologyTitleRestrictions"/>
-            </dct:title>
-            <rdfs:label xml:lang="en">
-                <xsl:value-of select="$ontologyLabelRestrictions"/>
-            </rdfs:label>
-            <dct:publisher>
-                <xsl:value-of select="$publisher"/>
-            </dct:publisher>
-            <dct:description xml:lang="en">
-                <xsl:value-of select="$ontologyDescriptionRestrictions"/>
-            </dct:description>
-            <rdfs:comment>This version is automatically generated from <xsl:value-of select="tokenize(base-uri(.), '/')[last()]"/> on 
+            <xsl:if test="normalize-space($ontologyTitleRestrictions) != ''">
+                <dct:title xml:lang="en">
+                    <xsl:value-of select="$ontologyTitleRestrictions"/>
+                </dct:title>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($ontologyLabelRestrictions) != ''">
+                <rdfs:label xml:lang="en">
+                    <xsl:value-of select="$ontologyLabelRestrictions"/>
+                </rdfs:label>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($publisher) != ''">
+                <dct:publisher>
+                    <xsl:value-of select="$publisher"/>
+                </dct:publisher>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($ontologyDescriptionRestrictions) != ''">
+                <dct:description xml:lang="en">
+                    <xsl:value-of select="$ontologyDescriptionRestrictions"/>
+                </dct:description>
+            </xsl:if>
+            
+            <rdfs:comment>
+                This version is automatically generated from
+                <xsl:value-of select="tokenize(base-uri(.), '/')[last()]"/>
+                on
                 <xsl:value-of select="format-date(current-date(),'[Y0001]-[M01]-[D01]')"/>
-                </rdfs:comment>
-            <xsl:for-each select="$seeAlsoResources">
-                <rdfs:seeAlso rdf:resource="{.}"/>
-            </xsl:for-each>
-
-            <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="$issuedDate"/></dct:issued>
-            <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="$createdDate"/></dct:created>
-            <owl:versionInfo><xsl:value-of select="$versionInfo"/></owl:versionInfo>   
-            <owl:incompatibleWith><xsl:value-of select="$incompatibleWith"/></owl:incompatibleWith>
-            <owl:versionIRI rdf:resource="{fn:concat($restrictionsArtefactURI,'-',$versionInfo)}"/>
-<!--            <bibo:status><xsl:value-of select="$ontologyStatus"/></bibo:status>-->
-            <owl:priorVersion><xsl:value-of select="fn:concat($restrictionsArtefactURI,'-',$priorVersion)"/></owl:priorVersion>
-            <vann:preferredNamespaceUri><xsl:value-of select="$preferredNamespaceUri"/></vann:preferredNamespaceUri>
-            <vann:preferredNamespacePrefix><xsl:value-of select="$preferredNamespacePrefix"/></vann:preferredNamespacePrefix>
-            <dct:license><xsl:value-of select="$licenseLiteral"/></dct:license>
+            </rdfs:comment>
+            
+            <xsl:if test="exists($seeAlsoResources)">
+                <xsl:for-each select="$seeAlsoResources">
+                    <rdfs:seeAlso rdf:resource="{.}"/>
+                </xsl:for-each>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($issuedDate) != ''">
+                <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
+                    <xsl:value-of select="$issuedDate"/>
+                </dct:issued>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($createdDate) != ''">
+                <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
+                    <xsl:value-of select="$createdDate"/>
+                </dct:created>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($versionInfo) != ''">
+                <owl:versionInfo>
+                    <xsl:value-of select="$versionInfo"/>
+                </owl:versionInfo>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($incompatibleWith) != ''">
+                <owl:incompatibleWith>
+                    <xsl:value-of select="$incompatibleWith"/>
+                </owl:incompatibleWith>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($versionInfo) != ''">
+                <owl:versionIRI rdf:resource="{fn:concat($restrictionsArtefactURI, '-', $versionInfo)}"/>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($priorVersion) != ''">
+                <owl:priorVersion>
+                    <xsl:value-of select="fn:concat($restrictionsArtefactURI, '-', $priorVersion)"/>
+                </owl:priorVersion>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($preferredNamespaceUri) != ''">
+                <vann:preferredNamespaceUri>
+                    <xsl:value-of select="$preferredNamespaceUri"/>
+                </vann:preferredNamespaceUri>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($preferredNamespacePrefix) != ''">
+                <vann:preferredNamespacePrefix>
+                    <xsl:value-of select="$preferredNamespacePrefix"/>
+                </vann:preferredNamespacePrefix>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($licenseLiteral) != ''">
+                <dct:license>
+                    <xsl:value-of select="$licenseLiteral"/>
+                </dct:license>
+            </xsl:if>
             
         </owl:Ontology>
     </xsl:template>

--- a/src/shacl-shapes.xsl
+++ b/src/shacl-shapes.xsl
@@ -62,35 +62,94 @@
             <owl:imports rdf:resource="{$coreArtefactURI}"/>
             <owl:imports rdf:resource="{$restrictionsArtefactURI}"/>
             
-            <dct:title xml:lang="en">
-                <xsl:value-of select="$ontologyTitleShapes"/>
-            </dct:title>
-            <rdfs:label xml:lang="en">
-                <xsl:value-of select="$ontologyLabelShapes"/>
-            </rdfs:label>
-            <dct:publisher>
-                <xsl:value-of select="$publisher"/>
-            </dct:publisher>
-            <dct:description xml:lang="en">
-                <xsl:value-of select="$ontologyDescriptionShapes"/>
-            </dct:description>
-            <rdfs:comment>This version is automatically generated from <xsl:value-of
-                    select="tokenize(base-uri(.), '/')[last()]"/> on <xsl:value-of
-                    select="format-date(current-date(), '[Y0001]-[M01]-[D01]')"/>
+            <xsl:if test="normalize-space($ontologyTitleShapes) != ''">
+                <dct:title xml:lang="en">
+                    <xsl:value-of select="$ontologyTitleShapes"/>
+                </dct:title>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($ontologyLabelShapes) != ''">
+                <rdfs:label xml:lang="en">
+                    <xsl:value-of select="$ontologyLabelShapes"/>
+                </rdfs:label>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($publisher) != ''">
+                <dct:publisher>
+                    <xsl:value-of select="$publisher"/>
+                </dct:publisher>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($ontologyDescriptionShapes) != ''">
+                <dct:description xml:lang="en">
+                    <xsl:value-of select="$ontologyDescriptionShapes"/>
+                </dct:description>
+            </xsl:if>
+            
+            <rdfs:comment>
+                This version is automatically generated from
+                <xsl:value-of select="tokenize(base-uri(.), '/')[last()]"/>
+                on
+                <xsl:value-of select="format-date(current-date(), '[Y0001]-[M01]-[D01]')"/>
             </rdfs:comment>
-            <xsl:for-each select="$seeAlsoResources">
-                <rdfs:seeAlso rdf:resource="{.}"/>
-            </xsl:for-each>
-            <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="$issuedDate"/></dct:issued>
-            <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="$createdDate"/></dct:created>
-            <owl:versionInfo><xsl:value-of select="$versionInfo"/></owl:versionInfo>   
-            <owl:incompatibleWith><xsl:value-of select="$incompatibleWith"/></owl:incompatibleWith>
-            <owl:versionIRI rdf:resource="{fn:concat($shapeArtefactURI,'-',$versionInfo)}"/>
- <!--           <bibo:status><xsl:value-of select="$ontologyStatus"/></bibo:status>-->
-            <owl:priorVersion><xsl:value-of select="fn:concat($shapeArtefactURI,'-',$priorVersion)"/></owl:priorVersion>
-            <vann:preferredNamespaceUri><xsl:value-of select="$preferredNamespaceUri"/></vann:preferredNamespaceUri>
-            <vann:preferredNamespacePrefix><xsl:value-of select="$preferredNamespacePrefix"/></vann:preferredNamespacePrefix>
-            <dct:license><xsl:value-of select="$licenseLiteral"/></dct:license>
+            
+            <xsl:if test="exists($seeAlsoResources)">
+                <xsl:for-each select="$seeAlsoResources">
+                    <rdfs:seeAlso rdf:resource="{.}"/>
+                </xsl:for-each>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($issuedDate) != ''">
+                <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
+                    <xsl:value-of select="$issuedDate"/>
+                </dct:issued>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($createdDate) != ''">
+                <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
+                    <xsl:value-of select="$createdDate"/>
+                </dct:created>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($versionInfo) != ''">
+                <owl:versionInfo>
+                    <xsl:value-of select="$versionInfo"/>
+                </owl:versionInfo>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($incompatibleWith) != ''">
+                <owl:incompatibleWith>
+                    <xsl:value-of select="$incompatibleWith"/>
+                </owl:incompatibleWith>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($versionInfo) != ''">
+                <owl:versionIRI rdf:resource="{fn:concat($shapeArtefactURI, '-', $versionInfo)}"/>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($priorVersion) != ''">
+                <owl:priorVersion>
+                    <xsl:value-of select="fn:concat($shapeArtefactURI, '-', $priorVersion)"/>
+                </owl:priorVersion>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($preferredNamespaceUri) != ''">
+                <vann:preferredNamespaceUri>
+                    <xsl:value-of select="$preferredNamespaceUri"/>
+                </vann:preferredNamespaceUri>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($preferredNamespacePrefix) != ''">
+                <vann:preferredNamespacePrefix>
+                    <xsl:value-of select="$preferredNamespacePrefix"/>
+                </vann:preferredNamespacePrefix>
+            </xsl:if>
+            
+            <xsl:if test="normalize-space($licenseLiteral) != ''">
+                <dct:license>
+                    <xsl:value-of select="$licenseLiteral"/>
+                </dct:license>
+            </xsl:if>
             
         </owl:Ontology>
     </xsl:template>


### PR DESCRIPTION
This PR addresses the issue where all metadata fields were previously treated as mandatory and their omission should be allowed based on user configuration.
What’s implemented:

- All configurable metadata fields (e.g., dct:title, dct:issued, owl:priorVersion, etc.) are now conditionally included in the output only if their corresponding values are set.

  The logic checks:

      normalize-space($variable) != '' for strings

      exists($variable) for lists

    Users now have full control over the inclusion of metadata:

        To omit a metadata field, the user simply sets the corresponding config variable to:

            "" for strings

            () for lists


Example 
```
<!-- In config file -->
<xsl:variable name="priorVersion" select="''"/> <!-- omitted -->
<xsl:variable name="seeAlsoResources" select="()"/> <!-- omitted -->
<xsl:variable name="publisher" select="'Publications Office of the EU'"/> <!-- included -->
```
