### PR TITLE
Add human-readable, title-cased labels to SHACL artefacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ get-jena-cli-tools: jena/apache-jena/bin/riot
 jena/apache-jena/bin/riot:
 	@echo Installing jena-cli-tools
 	mkdir -p jena
-	cd jena  && curl -L -o jena.zip "https://dlcdn.apache.org/jena/binaries/apache-jena-5.3.0.zip" && unzip jena.zip && rm -rf jena.zip && ln -s apache-jena-* apache-jena
+	cd jena  && curl -L -o jena.zip "https://archive.apache.org/dist/jena/binaries/apache-jena-5.3.0.zip" && unzip jena.zip && rm -rf jena.zip && ln -s apache-jena-* apache-jena
 	@echo 'Jena riot tool path is jena/apache-jena/bin/riot'
 
 # install rdflib

--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -230,27 +230,80 @@
      <xd:doc>
         <xd:desc>
             Turns the local segment of a lexicalised qName into words, handling
-            acronyms and camel case properly.
+            acronyms and camel case properly. 
+            
+            If `useTitleCase` is true, then the first letter of the first word
+            is capitalized, and the rest of the words are lowercased (unless
+            they are acronyms, which are left as-is). For example,
+            "exposureDateTime" becomes "Exposure date time", and "hasURL"
+            becomes "Has URL".
+
+            If `useTitleCase` is set to false, the function splits the given
+            camel-cased label into individual words. For instance, "hasLongName"
+            becomes "has Long Name", and "hasURL" becomes "has URL".
         </xd:desc>
         <xd:param name="lexicalqName"/>
+        <xd:param name="useTitleCase"/>
     </xd:doc>
     <xsl:function name="f:lexicalQNameToWords" as="xs:string">
         <xsl:param name="lexicalqName" as="xs:string"/>
+        <xsl:param name="useTitleCase" as="xs:boolean?"/>
         <xsl:variable name="localName"
             select="fn:local-name-from-QName(f:buildQNameFromLexicalQName($lexicalqName))"/>
-        <xsl:sequence 
-            select="fn:string-join(f:getSegmentsFromCamelCaseText($localName), ' ')" />
+        <xsl:variable name="_fixedText" select="f:getSegmentsFromCamelCaseText($localName)"/>
+        <xsl:sequence select="
+            if ($useTitleCase = true()) then
+                f:toTitleCase($_fixedText)
+            else
+                $_fixedText
+        "/>
+    </xsl:function>
+
+    <xd:doc>
+        <xd:desc>
+            Translates space-separated words into title case. The first letter
+            of the first word is capitalized, the rest are lowercased (unless
+            the word is an acronym, which is left as-is). For example, "exposure
+            Date Time" becomes "Exposure date time", and "has URL" becomes "Has
+            URL".
+        </xd:desc>
+        <xd:param name="text"/>
+    </xd:doc>
+    <xsl:function name="f:toTitleCase" as="xs:string">
+        <xsl:param name="text" as="xs:string"/>
+        <xsl:variable name="normalized" select="normalize-space($text)"/>
+        <xsl:choose>
+            <xsl:when test="$normalized = upper-case($normalized)">
+                <xsl:sequence select="$normalized"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:variable name="words" select="tokenize($normalized, '\s+')" as="xs:string*"/>
+                <xsl:variable name="fixedWords" select="
+                    for $i in 1 to count($words)
+                        return
+                            if ($words[$i] = upper-case($words[$i])) then
+                                $words[$i]
+                            else if ($i = 1) then
+                                    upper-case(substring($words[$i], 1, 1)) 
+                                        || lower-case(substring($words[$i], 2))
+                                else
+                                    lower-case($words[$i])
+                "/>
+                <xsl:sequence select="fn:string-join($fixedWords, ' ')" />
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:function>
 
     <xd:doc>
         <xd:desc>
             Splits a camelCase name into a text. Supports acronyms.
+            Returns a single string with segments separated by spaces.
         </xd:desc>
         <xd:param name="text"/>
     </xd:doc>
     <!-- The underlying function works on a reversed text as this makes
     identification of the segments easier. -->
-    <xsl:function name="f:getSegmentsFromCamelCaseText" as="xs:string*">
+    <xsl:function name="f:getSegmentsFromCamelCaseText" as="xs:string">
         <xsl:param name="text" as="xs:string"/>
         <xsl:sequence 
             select="for $segment in f:_getSegmentsRec(functx:reverse-string($text))

--- a/src/owl-core-lib/descriptors-owl-core.xsl
+++ b/src/owl-core-lib/descriptors-owl-core.xsl
@@ -34,7 +34,7 @@
         <xsl:param name="elementUri"/>
         <rdf:Description rdf:about="{$elementUri}">
             <skos:prefLabel xml:lang="en">
-                <xsl:value-of select="f:lexicalQNameToWords($elementName)"/>
+                <xsl:value-of select="f:lexicalQNameToWords($elementName, false())"/>
             </skos:prefLabel>
         </rdf:Description>
     </xsl:template>

--- a/src/owl-core-lib/elements-owl-core.xsl
+++ b/src/owl-core-lib/elements-owl-core.xsl
@@ -237,7 +237,7 @@
         <xsl:variable name="name"
             select="
                 if (boolean($firstAttribute/@name)) then
-                    f:lexicalQNameToWords($firstAttribute/@name)
+                    f:lexicalQNameToWords($firstAttribute/@name, false())
                 else
                     fn:error(xs:QName('attribute'), concat($firstAttribute/@xmi:idref, ' - Attribute with no name'))"/>
         <xsl:variable name="className" select="$firstAttribute/../../@name" as="xs:string"/>

--- a/src/shacl-shape-lib/descriptors-shacl-shape.xsl
+++ b/src/shacl-shape-lib/descriptors-shacl-shape.xsl
@@ -36,10 +36,10 @@
         <rdf:Description rdf:about = "{$uri}">
             <xsl:choose>
                 <xsl:when test="$isPropertyShape=fn:true()">
-                    <sh:name><xsl:value-of select="f:lexicalQNameToWords($elementName)"/></sh:name> 
+                    <sh:name><xsl:value-of select="f:lexicalQNameToWords($elementName, true())"/></sh:name> 
                 </xsl:when>
                 <xsl:otherwise>
-                     <rdfs:label><xsl:value-of select="f:lexicalQNameToWords($elementName)"/></rdfs:label>  
+                     <rdfs:label><xsl:value-of select="f:lexicalQNameToWords($elementName, true())"/></rdfs:label>  
                 </xsl:otherwise>
             </xsl:choose>
         </rdf:Description>

--- a/src/shacl-shape-lib/elements-shacl-shape.xsl
+++ b/src/shacl-shape-lib/elements-shacl-shape.xsl
@@ -256,7 +256,7 @@
         <xsl:param name="attribute"/>
         <xsl:param name="className"/>
         <xsl:variable name="attributeURI" select="f:buildURIFromElement($attribute)"/>
-        <xsl:variable name="attributeName" select="f:lexicalQNameToWords($attribute/@name)"/>
+        <xsl:variable name="attributeName" select="f:lexicalQNameToWords($attribute/@name, false())"/>
         <xsl:variable name="attributeType" select="$attribute/properties/@type"/>
         <xsl:variable name="shapePropertyUri"
             select="f:buildPropertyShapeURI($className, $attribute/@name)"/>
@@ -334,7 +334,7 @@
             select="f:getAttributeValueToDisplay($attribute/bounds/@upper)"/>
         <xsl:variable name="datatypeURI" select="f:buildURIfromLexicalQName('xsd:integer')"/>
         <xsl:variable name="attributeURI" select="f:buildURIFromElement($attribute)"/>
-        <xsl:variable name="attributeName" select="f:lexicalQNameToWords($attribute/@name)"/>
+        <xsl:variable name="attributeName" select="f:lexicalQNameToWords($attribute/@name, false())"/>
         <xsl:variable name="shapePropertyUri"
             select="f:buildPropertyShapeURI($className, $attribute/@name)"/>
 

--- a/test/unitTests/test-common/test-camelcase.xspec
+++ b/test/unitTests/test-common/test-camelcase.xspec
@@ -14,38 +14,51 @@
         <x:scenario label="QName to words 1">
             <x:call function="f:lexicalQNameToWords">
                 <x:param name="lexicalqName">hasEPORole</x:param>
+                <x:param name="useTitleCase" select="false()"/>
             </x:call>
             <x:expect label="Transformation from Qname to words is valid" select="'has EPO Role'"/>
         </x:scenario>
         <x:scenario label="QName to words 2">
             <x:call function="f:lexicalQNameToWords">
                 <x:param name="lexicalqName">hasVehicleID</x:param>
+                <x:param name="useTitleCase" select="false()"/>
             </x:call>
             <x:expect label="Transformation from Qname to words is valid" select="'has Vehicle ID'"/>
         </x:scenario>
         <x:scenario label="QName to words 3">
             <x:call function="f:lexicalQNameToWords">
                 <x:param name="lexicalqName">hasUUID</x:param>
+                <x:param name="useTitleCase" select="false()"/>
             </x:call>
             <x:expect label="Transformation from Qname to words is valid" select="'has UUID'"/>
         </x:scenario>
         <x:scenario label="QName to words 4">
             <x:call function="f:lexicalQNameToWords">
                 <x:param name="lexicalqName">ESPD</x:param>
+                <x:param name="useTitleCase" select="false()"/>
             </x:call>
             <x:expect label="Transformation from Qname to words is valid" select="'ESPD'"/>
         </x:scenario>
         <x:scenario label="QName to words 5">
             <x:call function="f:lexicalQNameToWords">
                 <x:param name="lexicalqName">ESPDDocument</x:param>
+                <x:param name="useTitleCase" select="false()"/>
             </x:call>
             <x:expect label="Transformation from Qname to words is valid" select="'ESPD Document'"/>
         </x:scenario>
         <x:scenario label="QName to words 6">
             <x:call function="f:lexicalQNameToWords">
                 <x:param name="lexicalqName">hasLongName</x:param>
+                <x:param name="useTitleCase" select="false()"/>
             </x:call>
             <x:expect label="Transformation from Qname to words is valid" select="'has Long Name'"/>
+        </x:scenario>
+        <x:scenario label="QName to words 7 - using title case">
+            <x:call function="f:lexicalQNameToWords">
+                <x:param name="lexicalqName">hasVehicleID</x:param>
+                <x:param name="useTitleCase" select="true()"/>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'Has vehicle ID'"/>
         </x:scenario>
     </x:scenario>
     
@@ -112,6 +125,50 @@
                 <x:param name="text">DPSE</x:param>
             </x:call>
             <x:expect label="Transformation from Qname to words is valid" select="'DPSE'"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="toTitleCase">
+        <x:scenario label="toTitleCase 1">
+            <x:call function="f:toTitleCase">
+                <x:param name="words" select="'has Estimated Value'"/>
+            </x:call>
+            <x:expect label="Transformation of words from camel case to title case is valid - simple case" select="'Has estimated value'"/>
+        </x:scenario>
+
+        <x:scenario label="toTitleCase 2">
+            <x:call function="f:toTitleCase">
+                <x:param name="words" select="'has EPO Role'"/>
+            </x:call>
+            <x:expect label="Transformation of words from camel case to title case is valid - with acronym 1" select="'Has EPO role'"/>
+        </x:scenario>
+
+        <x:scenario label="toTitleCase 3">
+            <x:call function="f:toTitleCase">
+                <x:param name="words" select="'has Vehicle ID'"/>
+            </x:call>
+            <x:expect label="Transformation of words from camel case to title case is valid - with acronym 2" select="'Has vehicle ID'"/>
+        </x:scenario>
+
+        <x:scenario label="toTitleCase 4">
+            <x:call function="f:toTitleCase">
+                <x:param name="words" select="'has UUID'"/>
+            </x:call>
+            <x:expect label="Transformation of words from camel case to title case is valid - trailing acronym" select="'Has UUID'"/>
+        </x:scenario>
+
+        <x:scenario label="toTitleCase 5">
+            <x:call function="f:toTitleCase">
+                <x:param name="words" select="'ESPD'"/>
+            </x:call>
+            <x:expect label="Transformation of words from camel case to title case is valid - single acronym" select="'ESPD'"/>
+        </x:scenario>
+
+        <x:scenario label="toTitleCase 6">
+            <x:call function="f:toTitleCase">
+                <x:param name="words" select="'ESPD Response'"/>
+            </x:call>
+            <x:expect label="Transformation of words from camel case to title case is valid - leading acronym" select="'ESPD response'"/>
         </x:scenario>
     </x:scenario>
     

--- a/test/unitTests/test-common/test-utils.xspec
+++ b/test/unitTests/test-common/test-utils.xspec
@@ -208,8 +208,17 @@
     <x:scenario label="Scenario xsd:integer for testing function lexicalQNameToWords">
         <x:call function="f:lexicalQNameToWords">
             <x:param name="lexicalqName">xsd:longInteger</x:param> 
+            <x:param name="useTitleCase" select="false()"/>
         </x:call>
         <x:expect label="result" select="string('long Integer')"/>
+    </x:scenario>
+
+    <x:scenario label="Scenario xsd:integer for testing function lexicalQNameToWords - title case">
+        <x:call function="f:lexicalQNameToWords">
+            <x:param name="lexicalqName">xsd:longInteger</x:param> 
+            <x:param name="useTitleCase" select="true()"/>
+        </x:call>
+        <x:expect label="result" select="string('Long integer')"/>
     </x:scenario>
     
     

--- a/test/unitTests/test-shacl-shape-lib/test-descriptors-shacl-shape.xspec
+++ b/test/unitTests/test-shacl-shape-lib/test-descriptors-shacl-shape.xspec
@@ -24,7 +24,7 @@
         <x:expect label="there is rdf:Description"
             test="boolean(/rdf:Description[@rdf:about='http:/fake.uri#something'])"
         />
-        <x:expect label="correct label" test="rdf:Description/rdfs:label/text() = 'Dynamic Procedure'"/>
+        <x:expect label="correct label" test="rdf:Description/rdfs:label/text() = 'Dynamic procedure'"/>
         
         
     </x:scenario>
@@ -40,7 +40,7 @@
         <x:expect label="there is rdf:Description"
             test="boolean(/rdf:Description[@rdf:about='http:/fake.uri#something'])"
         />
-        <x:expect label="correct label" test="rdf:Description/sh:name/text() = 'Dynamic Procedure'"/>
+        <x:expect label="correct label" test="rdf:Description/sh:name/text() = 'Dynamic procedure'"/>
         
         
     </x:scenario>

--- a/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shape.xspec
+++ b/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shape.xspec
@@ -141,7 +141,7 @@
             as="xs:string"
             select="'http://data.europa.eu/a4g/data-shape#epo-FrameworkAgreementTerm-epo-hasMaximumParticipantsNumber'"/>
         <x:expect label="correct node-property shapes link" test="boolean(/rdf:Description[@rdf:about='http://data.europa.eu/a4g/data-shape#epo-FrameworkAgreementTerm']/sh:property[@rdf:resource=$testedPropShapeUri])"/>
-        <x:expect label="property shape: correct name" test="/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:name/text() = 'has Maximum Participants Number'"/>
+        <x:expect label="property shape: correct name" test="/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:name/text() = 'Has maximum participants number'"/>
         <x:expect label="property shape: correct datatype" test="boolean(/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:datatype[@rdf:resource='http://www.w3.org/2001/XMLSchema#integer'])"/>
         <x:expect label="property shape: correct maxCount" test="/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:maxCount = 1"/>
         <x:expect label="property shape: correct description" test="boolean(/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:description)"/>


### PR DESCRIPTION
The change increases the human readability of property names in SHACL artefacts by generating more user-friendly labels by converting names like `hasPostalCode` into readable labels such as "Has postal code". The change is enabled for labels in the SHACL artefact. It can be easily enabled for other artefacts in the future.

Scope of changes:
* Implemented extension for generating human-readable title-cased labels (e.g. `My label`)
* Enabled title-cased labels for `sh:name` and `rdfs:label` in SHACL artefact generation
* Implemented dedicated tests for the new extension
* Updated existing tests affected by these changes