### PR TITLE
Extend ontology import configuration and introduce a dedicated `imports.xml` file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ get-saxon: saxon/saxon.jar
 saxon/saxon.jar:
 	@echo Installing saxon
 	mkdir -p saxon
-	cd saxon  && curl -L -o saxon.zip "https://kumisystems.dl.sourceforge.net/project/saxon/Saxon-HE/10/Java/SaxonHE10-6J.zip" && unzip saxon.zip && rm -rf saxon.zip
+	cd saxon  && curl -L -o saxon.zip "https://sourceforge.net/projects/saxon/files/Saxon-HE/10/Java/SaxonHE10-6J.zip" && unzip saxon.zip && rm -rf saxon.zip
 	cd saxon && mv saxon-he-10.6.jar saxon.jar
 	@echo 'Saxon path is saxon/saxon.jar'
 
@@ -57,7 +57,7 @@ get-jena-cli-tools: jena/apache-jena/bin/riot
 jena/apache-jena/bin/riot:
 	@echo Installing jena-cli-tools
 	mkdir -p jena
-	cd jena  && curl -L -o jena.zip "https://dlcdn.apache.org/jena/binaries/apache-jena-5.3.0.zip" && unzip jena.zip && rm -rf jena.zip && ln -s apache-jena-* apache-jena
+	cd jena  && curl -L -o jena.zip "https://archive.apache.org/dist/jena/binaries/apache-jena-5.3.0.zip" && unzip jena.zip && rm -rf jena.zip && ln -s apache-jena-* apache-jena
 	@echo 'Jena riot tool path is jena/apache-jena/bin/riot'
 
 # install rdflib

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ TURTLE_FILELIST=$(shell ls ${ONTOLOGY_FOLDER_PATH}/*.ttl)
 WIDOCO_RDF_INPUT_FILE_PATH?=test/reasoning-investigation/model-2020-12-16/ePO_restrictions.rdf
 WIDOCO_OUTPUT_FOLDER_PATH?=output/widoco
 NAMESPACES_USER_XML_FILE_PATH?=${MODEL2OWL_FOLDER}/test/ePO-default-config/namespaces.xml
+IMPORTS_XML_FILE_PATH?=${ABSOLUTE_MODEL2OWL_FOLDER}/test/ePO-default-config/imports.xml
 INTERM_FOLDER_PATH?=${ABSOLUTE_MODEL2OWL_FOLDER}/.temp
 ENRICHED_NAMESPACES_XML_PATH:=${INTERM_FOLDER_PATH}/enriched-namespaces.xml
 NAMESPACES_AS_RDFPIPE_ARGS=$(shell ${MODEL2OWL_FOLDER}/scripts/get_namespaces.sh ${ENRICHED_NAMESPACES_XML_PATH})
@@ -82,7 +83,9 @@ install:  get-saxon get-rdflib get-widoco get-jena-cli-tools
 # Run unit_tests
 unit-tests:
 	@make test-prerequisites
-	@mvn install -Dsaxon.options.enrichedNamespacesPath=${ENRICHED_NAMESPACES_XML_PATH}
+	@mvn install \
+		-Dsaxon.options.enrichedNamespacesPath=${ENRICHED_NAMESPACES_XML_PATH} \
+		-Dsaxon.options.importsPath=${IMPORTS_XML_FILE_PATH}
 
 # Actions required in order to setup the environment for testing purposes.
 # Usage (`[]` denotes an optional argument; if omited, default value will be used):
@@ -167,8 +170,10 @@ generate-convention-SVRL-report:
 # make (owl-core | owl-restrictions | shacl) [XMI_INPUT_FILE_PATH=/path/to/cm.xmi] 
 #	[OUTPUT_FOLDER_PATH=/output/directory]
 #	[NAMESPACES_USER_XML_FILE_PATH=/path/to/namespaces.xml]
+#	[IMPORTS_XML_FILE_PATH=/path/to/imports.xml]
 # where:
-#   NAMESPACES_USER_XML_FILE_PATH: path to the *.xml file provided by a user
+#   NAMESPACES_USER_XML_FILE_PATH: path to the *.xml file containing namespaces provided by a user
+#	IMPORTS_XML_FILE_PATH: path to the *.xml file containing URIs to be imported provided by a user
 #
 # Example:
 # make owl-core XMI_INPUT_FILE_PATH=/home/mypc/work/model2owl/eNotice_CM.xml OUTPUT_FOLDER_PATH=./my-folder
@@ -176,7 +181,8 @@ owl-core:
 	@make gen-enriched-ns-file
 	@java -jar ${SAXON} -s:${XMI_INPUT_FILE_PATH} -xsl:${MODEL2OWL_FOLDER}/src/owl-core.xsl \
 		-o:${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}.tmp.rdf \
-		enrichedNamespacesPath="${ENRICHED_NAMESPACES_XML_PATH}"
+		enrichedNamespacesPath="${ENRICHED_NAMESPACES_XML_PATH}" \
+		importsPath="${IMPORTS_XML_FILE_PATH}"
 	@make convert-between-serialization-formats INPUT_FORMAT=${RDF_XML_MIME_TYPE} \
 		OUTPUT_FORMAT=${RDF_XML_MIME_TYPE} \
 		FILE_PATH=${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}.tmp.rdf \
@@ -189,7 +195,8 @@ owl-restrictions:
 	@make gen-enriched-ns-file
 	@java -jar ${SAXON} -s:${XMI_INPUT_FILE_PATH} -xsl:${MODEL2OWL_FOLDER}/src/owl-restrictions.xsl \
 		-o:${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_restrictions.tmp.rdf \
-		enrichedNamespacesPath="${ENRICHED_NAMESPACES_XML_PATH}"
+		enrichedNamespacesPath="${ENRICHED_NAMESPACES_XML_PATH}" \
+		importsPath="${IMPORTS_XML_FILE_PATH}"
 	@make convert-between-serialization-formats INPUT_FORMAT=${RDF_XML_MIME_TYPE} \
 		OUTPUT_FORMAT=${RDF_XML_MIME_TYPE} \
 		FILE_PATH=${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_restrictions.tmp.rdf \
@@ -202,7 +209,8 @@ shacl:
 	@make gen-enriched-ns-file
 	@java -jar ${SAXON} -s:${XMI_INPUT_FILE_PATH} -xsl:${MODEL2OWL_FOLDER}/src/shacl-shapes.xsl \
 		-o:${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_shapes.tmp.rdf \
-		enrichedNamespacesPath="${ENRICHED_NAMESPACES_XML_PATH}"
+		enrichedNamespacesPath="${ENRICHED_NAMESPACES_XML_PATH}" \
+		importsPath="${IMPORTS_XML_FILE_PATH}"
 	@make convert-between-serialization-formats INPUT_FORMAT=${RDF_XML_MIME_TYPE} \
 		OUTPUT_FORMAT=${RDF_XML_MIME_TYPE} \
 		FILE_PATH=${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_shapes.tmp.rdf \

--- a/README.md
+++ b/README.md
@@ -97,14 +97,20 @@ make owl-core XMI_INPUT_FILE_PATH=/home/mypc/work/model2owl/file1.xml OUTPUT_FOL
   * parameters:
     * XMI_INPUT_FILE_PATH - path to the xmi file
     * OUTPUT_FOLDER_PATH - path to the folder that stores the output
+    * NAMESPACES_USER_XML_FILE_PATH: path to the *.xml file containing namespaces
+    * IMPORTS_XML_FILE_PATH: path to the *.xml file containing ontology URIs to be imported
 * **owl-restrictions** - this generates heavyweight ontology with additional axioms suitable for reasoning purposes from the UML export (xml/xmi)
   * parameters:
     * XMI_INPUT_FILE_PATH - path to the xmi file
     * OUTPUT_FOLDER_PATH - path to the folder that stores the output
+    * NAMESPACES_USER_XML_FILE_PATH: path to the *.xml file containing namespaces
+    * IMPORTS_XML_FILE_PATH: path to the *.xml file containing ontology URIs to be imported
 * **shacl** - this generates data shapes suitable for validation from the UML export (xml/xmi)
   * parameters:
     * XMI_INPUT_FILE_PATH - path to the xmi file
     * OUTPUT_FOLDER_PATH - path to the folder that stores the output
+    * NAMESPACES_USER_XML_FILE_PATH: path to the *.xml file containing namespaces
+    * IMPORTS_XML_FILE_PATH: path to the *.xml file containing ontology URIs to be imported
 * **generate-html-docs-from-rdf** - this generates html documentation using widoco from a rdf file
   * parameters:
     * WIDOCO_RDF_INPUT_FILE_PATH - path to the rdf file
@@ -134,9 +140,10 @@ Steps:
 then activate it by using  ``source model2owl-venv/bin/activate``.
 
 ### Configuration
-The model2owl configuration is formed from 4 files that should be in one folder:
+The model2owl configuration is formed from 5 files that should be in one folder:
 * config-parameters.xsl - main config variables
 * namespaces.xml - add namespaces that are used in your UML model
+* imports.xml - A set of URIs to be included for importing in the generated ontologies using the `owl:imports` property
 * umlToXsdDataTypes.xml - mapping between uml to xsd data types
 * xsdAndRdfDataTypes.xml - configure datatypes used
 
@@ -200,13 +207,34 @@ Example
 ```shell
 # to add prefix you need a name and the URI
  <prefix name="foaf" value="http://xmlns.com/foaf/0.1/"/>
-# to have an import statement in the final output 
-# add importURI attribute to the definition above
- <prefix name="dct" value="http://purl.org/dc/terms/" importURI="http://purl.org/dc/terms/"/>
- 
-#Output will have the following import statement
+```
+
+#### Imported ontologies configuration
+URIs of ontologies to be declared for import within generated ontologies (for
+core, restrictions or SHACL shapes artefacts) can be specified in the
+imports.xml file. The file includes sections for shared URIs, which apply to all
+artefact types, as well as sections for specific artefact types.
+```xml
+<imports xmlns="http://publications.europa.eu/ns/">
+    <!-- affects all three artefacts -->
+    <all>
+        <import uri="http://purl.org/dc/terms/"/>
+    </all>
+    <!-- affects SHACL artefact -->
+    <shacl>
+        <import uri="http://data.europa.eu/a4g/data-shape#awa-shape"/>
+    </shacl>
+</imports>
+```
+This will cause all RDF output files to include the following import statement for the declared ontology:
+```xml
 <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
 ```
+In addition, the SHACL artefact will contain:
+```xml
+<owl:imports rdf:resource="http://data.europa.eu/a4g/data-shape#awa-shape"/>
+```
+
 #### XSD/RDF datatypes
 Use xsdAndRdfDataTypes.xml file to define the datatypes used in the UML model.
 

--- a/README.md
+++ b/README.md
@@ -199,8 +199,7 @@ By adjusting these variables, it is possible to customize whether specific artef
 providing fine control over the content of each output.
 
 #### Namespaces configuration
-In the namespaces.xml file you can add the namespaces that you use in UML model and also can control which of them should
-appear as import in the final output.
+In the namespaces.xml file you can add the namespaces that you use in UML model.
 
 Example
 
@@ -226,13 +225,28 @@ artefact types, as well as sections for specific artefact types.
     </shacl>
 </imports>
 ```
-This will cause all RDF output files to include the following import statement for the declared ontology:
+This will cause **all RDF output files** to include the following import statement for the declared ontology:
 ```xml
-<owl:imports rdf:resource="http://purl.org/dc/terms/"/>
+<!-- in core.rdf, the resource <http://example.com/core> is of type owl:Ontology -->
+<rdf:Description rdf:about="http://example.com/core">
+    <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
+</rdf:Description>
+
+<!-- in core_restrictions.rdf, the resource <http://example.com/core-restriction> is of type owl:Ontology -->
+<rdf:Description rdf:about="http://example.com/core-restriction">
+    <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
+</rdf:Description>
+
+<!-- in core_shapes.rdf, the resource <http://example.com/core-shape> is of type owl:Ontology -->
+<rdf:Description rdf:about="http://example.com/core-shape">
+    <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
+</rdf:Description>
 ```
-In addition, the SHACL artefact will contain:
+In addition, the below statement will be present **only in the SHACL artefact**:
 ```xml
-<owl:imports rdf:resource="http://data.europa.eu/a4g/data-shape#awa-shape"/>
+<rdf:Description rdf:about="http://data.europa.eu/a4g/ontology#core-restriction">
+    <owl:imports rdf:resource="http://data.europa.eu/a4g/data-shape#awa-shape"/>
+</rdf:Description>
 ```
 
 #### XSD/RDF datatypes

--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -28,6 +28,11 @@
         else fn:error(xs:QName('missing-parameter'), 'enrichedNamespacesPath is not given.')
     "/>
 
+    <!-- path to a file with a set of URIs to be included for importing in the
+    generated ontologies using the `owl:imports` property -->
+    <xsl:param name="importsPath"/>
+    <xsl:variable name="urisToBeImported" select="fn:doc($importsPath)"/>
+
     <xd:doc>
         <xd:desc> Lookup a data-type in the xsd and rdf accepted data-type document (usually an
             external file with xsd and rdf data-types definitions) and return false or the data-type

--- a/src/html-conventions-lib/generalization-html-conventions.xsl
+++ b/src/html-conventions-lib/generalization-html-conventions.xsl
@@ -53,9 +53,9 @@
                 <xsl:call-template name="generalizationUnidirectionalConnectorsDirection">
                     <xsl:with-param name="generalizationConnector" select="."/>
                 </xsl:call-template>
-                <xsl:call-template name="generalizationMissingOrInvalidClassGeneralization">
+                <!-- <xsl:call-template name="generalizationMissingOrInvalidClassGeneralization">
                     <xsl:with-param name="generalizationConnector" select="."/>
-                </xsl:call-template>
+                </xsl:call-template> -->
             </xsl:if>
         </xsl:variable>
         <xsl:if test="boolean($generalizationChecks)">

--- a/src/owl-core.xsl
+++ b/src/owl-core.xsl
@@ -61,9 +61,12 @@
     <xsl:template name="ontology-header">
 
         <owl:Ontology rdf:about="{$coreArtefactURI}">         
-            <xsl:for-each select="$internalNamespacePrefixes/*:prefixes/*:prefix/@importURI">              
+            <xsl:for-each select="$urisToBeImported/*:imports/*:all/*:import/@uri">              
                 <owl:imports rdf:resource="{.}"/>
-            </xsl:for-each>      
+            </xsl:for-each>
+            <xsl:for-each select="$urisToBeImported/*:imports/*:core/*:import/@uri">              
+                <owl:imports rdf:resource="{.}"/>
+            </xsl:for-each>
              
             <dct:title xml:lang="en">
                 <xsl:value-of select="$ontologyTitleCore"/>

--- a/src/owl-restrictions.xsl
+++ b/src/owl-restrictions.xsl
@@ -54,9 +54,12 @@
     </xd:doc>
     <xsl:template name="ontology-header">
         <owl:Ontology rdf:about="{$restrictionsArtefactURI}">            
-            <xsl:for-each select="$internalNamespacePrefixes/*:prefixes/*:prefix/@importURI">              
+            <xsl:for-each select="$urisToBeImported/*:imports/*:all/*:import/@uri">              
                 <owl:imports rdf:resource="{.}"/>
-            </xsl:for-each>      
+            </xsl:for-each>
+            <xsl:for-each select="$urisToBeImported/*:imports/*:restrictions/*:import/@uri">              
+                <owl:imports rdf:resource="{.}"/>
+            </xsl:for-each>
             <owl:imports rdf:resource="{$coreArtefactURI}"/>
             <dct:title xml:lang="en">
                 <xsl:value-of select="$ontologyTitleRestrictions"/>

--- a/src/shacl-shapes.xsl
+++ b/src/shacl-shapes.xsl
@@ -55,10 +55,12 @@
     </xd:doc>
     <xsl:template name="ontology-header">
         <owl:Ontology rdf:about="{$shapeArtefactURI}">
-            
-            <xsl:for-each select="$internalNamespacePrefixes/*:prefixes/*:prefix/@importURI">              
+            <xsl:for-each select="$urisToBeImported/*:imports/*:all/*:import/@uri">              
                 <owl:imports rdf:resource="{.}"/>
-            </xsl:for-each>      
+            </xsl:for-each>
+            <xsl:for-each select="$urisToBeImported/*:imports/*:shacl/*:import/@uri">              
+                <owl:imports rdf:resource="{.}"/>
+            </xsl:for-each>
             <owl:imports rdf:resource="{$coreArtefactURI}"/>
             <owl:imports rdf:resource="{$restrictionsArtefactURI}"/>
             

--- a/src/xml/enriched-namespaces.xsl
+++ b/src/xml/enriched-namespaces.xsl
@@ -20,11 +20,6 @@
         <prefixes>
             <xsl:for-each select="/*:prefixes/*:prefix">
                 <prefix name="{./@name}" value="{./@value}">
-                    <xsl:if test="boolean(./@importURI)">
-                        <xsl:attribute name="importURI">
-                            <xsl:value-of select="./@importURI" />
-                        </xsl:attribute>
-                    </xsl:if>
                 </prefix>
             </xsl:for-each>
             <prefix name="{fn:concat($moduleReference, '-res')}" 

--- a/test/ePO-default-config/imports.xml
+++ b/test/ePO-default-config/imports.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<imports xmlns="http://publications.europa.eu/ns/">
+    <!-- affects all three artefacts -->
+    <all>
+        <import uri="http://purl.org/dc/terms/"/>
+        <import uri="http://www.w3.org/2004/02/skos/core#"/>
+        <import uri="https://data.europa.eu/m8g"/>
+        <import uri="http://www.w3.org/ns/adms"/>
+    </all>
+    <!-- affects core artefact -->
+    <core></core>
+    <!-- affects restrictions artefact -->
+    <restrictions></restrictions>
+    <!-- affects SHACL artefact -->
+    <shacl></shacl>
+</imports>

--- a/test/ePO-default-config/namespaces.xml
+++ b/test/ePO-default-config/namespaces.xml
@@ -9,9 +9,9 @@
     <prefix name="rdfs" value="http://www.w3.org/2000/01/rdf-schema#"/>
 
     <prefix name="foaf" value="http://xmlns.com/foaf/0.1/"/>
-    <prefix name="dct" value="http://purl.org/dc/terms/" importURI="http://purl.org/dc/terms/"/>
+    <prefix name="dct" value="http://purl.org/dc/terms/"/>
     <prefix name="org" value="http://www.w3.org/ns/org#"/>
-    <prefix name="skos" value="http://www.w3.org/2004/02/skos/core#" importURI="http://www.w3.org/2004/02/skos/core#"/>
+    <prefix name="skos" value="http://www.w3.org/2004/02/skos/core#"/>
     <prefix name="eli" value="http://data.europa.eu/eli/ontology#"/>
 
     <prefix name="epo" value="http://data.europa.eu/a4g/ontology#"/>
@@ -33,8 +33,8 @@
     <prefix name="at-voc" value="http://publications.europa.eu/resource/authority/"/>
     <prefix name="time" value="http://www.w3.org/2006/time#"/>
     <prefix name="locn" value="http://www.w3.org/ns/locn#"/>
-    <prefix name="cccev" value="http://data.europa.eu/m8g/" importURI="https://data.europa.eu/m8g"/>
-    <prefix name="cv" value="http://data.europa.eu/m8g/" importURI="https://data.europa.eu/m8g"/>
+    <prefix name="cccev" value="http://data.europa.eu/m8g/"/>
+    <prefix name="cv" value="http://data.europa.eu/m8g/"/>
     <prefix name="core" value="http://data.europa.eu/m8g/"/>
     <prefix name="cpv" value="http://data.europa.eu/m8g/"/>
     <prefix name="cpsv" value="http://data.europa.eu/m8g/"/>
@@ -44,6 +44,6 @@
     <prefix name="person" value="http://www.w3.org/ns/person#"/>
     <prefix name="at-voc-new" value="http://publications.europa.eu/resource/authority/new/"/>
     <prefix name="legal" value="http://www.w3.org/ns/legal-entity#"/>
-    <prefix name="adms" value="http://www.w3.org/ns/adms#" importURI="http://www.w3.org/ns/adms"/>
+    <prefix name="adms" value="http://www.w3.org/ns/adms#"/>
     
 </prefixes>


### PR DESCRIPTION
The change extends ontology import configuration and introduces a dedicated `imports.xml` file enabling fine-grained configuration of URIs per generated RDF artefact.

Scope of changes:
* Updated default configuration: introduced `imports.xml` and removed imports from `namespaces.xml`
* Modified `owl:imports` generation logic to use the new XML file
* Updated affected Makefile recipes to accept a new parameter `IMPORTS_XML_FILE_PATH`, with a fallback to the default `imports.xml` file
* Revised the README to document new make recipe parameters and the new configuration file

Note: Generation of "base" imports is retained—restrictions artefact always imports the core artefact, and the SHACL artefact always imports both core and restrictions. Therefore, there is no need to specify these in the `imports.xml` file.

Demonstration of the change is available on a dedicated branch in the model2owl-boilerplate repository. The end-to-end test demonstrates generated RDF artefacts (see the exemplary generated RDF statements for [core](https://github.com/meaningfy-ws/model2owl-boilerplate/blob/feature/M2O3-42/implementation/demo_ontology/owl_ontology/demo_ontology_CM.ttl#L3652), [restrictions](https://github.com/meaningfy-ws/model2owl-boilerplate/blob/feature/M2O3-42/implementation/demo_ontology/owl_ontology/demo_ontology_CM_restrictions.ttl#L88) and [SHACL shapes](https://github.com/meaningfy-ws/model2owl-boilerplate/blob/feature/M2O3-42/implementation/demo_ontology/shacl_shapes/demo_ontology_CM_shapes.ttl#L6692)) for the given [imports specification](https://github.com/meaningfy-ws/model2owl-boilerplate/blob/feature/M2O3-42/implementation/demo_ontology/model2owl-config/imports.xml).