### PR TITLE
Parametrize URI construction for SHACL node shapes

### DIFF
--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -576,7 +576,8 @@
     </xd:doc>
     <xsl:function name="f:buildShapeURI">
         <xsl:param name="uri"/>
-        <xsl:sequence select="fn:concat($base-shape-uri, $defaultDelimiter, f:normaliseURI($uri))"/>
+        <xsl:sequence
+            select="fn:concat($base-shape-uri, $defaultDelimiter, f:normaliseURI($uri), $nodeShapeURIsuffix)"/>
     </xsl:function>
 
 

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -46,6 +46,9 @@
 
     <!-- when a delimiter is missing in the base URI of a namespace, use this default value-->
     <xsl:variable name="defaultDelimiter" select="'#'"/>
+    
+    <!-- suffix for URIs of sh:NodeShape instances in the SHACL artefact -->
+    <xsl:variable name="nodeShapeURIsuffix" select="'Shape'"/>
 
     <!-- types of elements and names for attribute types that are acceptable to produce object properties -->
     <xsl:variable name="acceptableTypesForObjectProperties"

--- a/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shape.xspec
+++ b/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shape.xspec
@@ -21,6 +21,8 @@
     <x:scenario label="Scenario for testing template with match 'element[@xmi:type = 'uml:Class']">
         <x:context href="../../testData/ePO-CM_v.3.0.1.eap.xmi" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[224]"/>
         <x:expect label="there is a sh:NodeShape" test="boolean(sh:NodeShape) "/>
+        <x:expect label="there is a correct node shape URI"
+            test="sh:NodeShape/@rdf:about='http://data.europa.eu/a4g/data-shape#epo-DocumentShape'"/>
         <x:expect label="there is a rdfs:label" test="boolean(rdf:Description/rdfs:label)"/>
 <!--        <x:expect label="there is a rdfs:label" test="boolean(sh:NodeShape/rdfs:label)"/>-->
         <x:expect label="there is  rdfs:comment" test="boolean(rdf:Description/rdfs:comment)"/>
@@ -140,7 +142,8 @@
         <x:variable name="testedPropShapeUri"
             as="xs:string"
             select="'http://data.europa.eu/a4g/data-shape#epo-FrameworkAgreementTerm-epo-hasMaximumParticipantsNumber'"/>
-        <x:expect label="correct node-property shapes link" test="boolean(/rdf:Description[@rdf:about='http://data.europa.eu/a4g/data-shape#epo-FrameworkAgreementTerm']/sh:property[@rdf:resource=$testedPropShapeUri])"/>
+        <x:expect label="correct node-property shapes link"
+            test="boolean(/rdf:Description[@rdf:about='http://data.europa.eu/a4g/data-shape#epo-FrameworkAgreementTermShape']/sh:property[@rdf:resource=$testedPropShapeUri])"/>
         <x:expect label="property shape: correct name" test="/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:name/text() = 'has Maximum Participants Number'"/>
         <x:expect label="property shape: correct datatype" test="boolean(/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:datatype[@rdf:resource='http://www.w3.org/2001/XMLSchema#integer'])"/>
         <x:expect label="property shape: correct maxCount" test="/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:maxCount = 1"/>


### PR DESCRIPTION
The change parametrizes URIs of `sh:NodeShape` instances and sets `Shape` as the default URI suffix. It aims to increase readability.

Scope of changes:
* Updated utility function for building shape URIs
* Added configuration parameter `nodeShapeURIsuffix` to specify suffixes for `sh:NodeShape` URIs in the SHACL artefact, defaulting to `Shape`
* Updated tests to verify correctness of generated URIs for sh:NodeShape and sh:PropertyShape

Note: Although the `f:buildShapeURI` function is not explicitly defined as being dedicated to Node URIs, all current usages involve node URI construction. Therefore, the change was applied directly within the utility function rather than modifying the individual function calls.