### PR TITLE
Fix several issues related to rendering of autogenerated content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ MODEL_EAP_FILE_PATH?=
 
 # respec variables with default values
 RESPEC_JSON_INDENTATION?=2
-RESPEC_DATA_JSON_PATH?=
+RESPEC_DATA_JSON_PATH?=${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_respec.json
 RESPEC_METADATA_JSON_PATH?=${ABSOLUTE_MODEL2OWL_FOLDER}/test/ePO-default-config/metadata.json
 RESPEC_INPUT_ASSETS_DIR=${ABSOLUTE_MODEL2OWL_FOLDER}/respec-resources/assets
 SDS_FILES_JSON_LOCATION=.assets.sdsSection
@@ -464,8 +464,9 @@ generate-respec:
 	handle_artefact_file $$ext_md_json "UML XMI model file" "${XMI_INPUT_FILE_PATH}" ; \
 	handle_artefact_file $$ext_md_json "UML EAP model file" "${MODEL_EAP_FILE_PATH}" ; \
 	\
-	# generate the respec JSON if not provided \
-	if [ -z ${RESPEC_DATA_JSON_PATH} ]; then \
+	# generate a respec JSON if not provided \
+	if [ ! -e ${RESPEC_DATA_JSON_PATH} ]; then \
+		echo "Generating a ReSpec JSON data file..."; \
 		$(MAKE) respec-json XMI_INPUT_FILE_PATH=${XMI_INPUT_FILE_PATH} OUTPUT_FOLDER_PATH=${OUTPUT_FOLDER_PATH} ; \
 	fi; \
 	\

--- a/respec-resources/templates/base.j2
+++ b/respec-resources/templates/base.j2
@@ -21,14 +21,14 @@
             {% set _issueBody = "Explain%20your%20issue%20for%20" 
              ~ metadata.navigation.self 
              ~ "%23" 
-             ~ ((entity.label[language] ~ '.' ~ prop.label[language]) | replace(" ","") | urlencode) %}
+             ~ ((entity.label[language] ~ '.' ~ prop.label[language]) | replace(" ","") | urlencode| title ) %}
        
             {% else %}
             {% set _issueTitle = "Issue%20for%20'" ~ entity.label[language] ~ "'" %}
             {% set _issueBody = "Explain%20your%20issue%20for%20" 
              ~ metadata.navigation.self 
              ~ "%23" 
-             ~ (entity.label[language] | replace(" ","") | urlencode) %}
+             ~ (entity.label[language] | replace(" ","") | urlencode| title ) %}
         {% endif %}
 
         <a href="{{ metadata.feedbackUrl }}/new?title={{ _issueTitle }}&body={{ _issueBody }}" target="_blank" rel="noopener noreferrer" >
@@ -39,7 +39,7 @@
 
 {% macro renderEntity(entity) %}
     <section>
-        <h3 id="{{ entity.label[language]| replace(" ","") |urlencode }}">
+        <h3 id="{{ entity.label[language]| replace(" ","") | urlencode | title }}">
             <a href="{{ entity.uri }}"
                 data-toggle="tooltip"
                 data-content="{{ entity.uri }}"
@@ -78,7 +78,7 @@
             </dt>
             {% if ((entity.properties | length) > 0 ) %}
                 <dd>
-                    For this entity the following properties are defined: {%- for prop in entity['properties'] | sort(attribute=sortattr) %} <a href="#{{ (entity.label[language] ~ '.' ~ prop.label[language]) | replace(" ","") | urlencode }}">{{ prop.label[language] }}</a>
+                    For this entity the following properties are defined: {%- for prop in entity['properties'] | sort(attribute=sortattr) %} <a href="#{{ (entity.label[language] ~ '.' ~ prop.label[language]) | replace(" ","") | urlencode | title }}">{{ prop.label[language] }}</a>
                     {% if not loop.last %},{% endif %}
                 {%- endfor %}.
                 </dd>
@@ -117,7 +117,7 @@
                     </thead>
                     <tbody class="supertype">
                         {% for prop in entity['properties'] | sort(attribute=sortattr) %}
-                            <tr id="{{ (entity.label[language] ~ '.' ~ prop.label[language]) | replace(" ","") | urlencode }}"
+                            <tr id="{{ (entity.label[language] ~ '.' ~ prop.label[language]) | replace(" ","") | urlencode | title }}"
                                 typeof="rdf:Property"
                                 resource="{{ prop.uri }}"
                                 class="class mandatory">-
@@ -129,15 +129,14 @@
                                         {{ prop.label[language] }}</a>
                                 </td>
                                 <td>
-                                    {% for range in prop.scopedrange %}
+                                    {% for range in prop.range %}
                                         {% if range['range_uri'] == range['range_puri'] %}
-                                            <a href="#{{ range['range_label'][language] | replace(" ","") | urlencode }}"
+                                            <a href="#{{ range['range_label'][language] | replace(" ","") | urlencode | title }}"
                                             data-toggle="tooltip"
                                             data-content="{{ range['range_puri'] }}"
-                                            data-placement="right"
-                                            class="no-prefix">{{ range['range_label'][language] }}</a>
+                                            data-placement="right">{{ range['range_curie'] }}</a>
                                         {% else %}
-                                            <a href="#{{ range['range_label'][language] | replace(" ","") | urlencode }}" data-placement="right" class="no-prefix">{{ range['range_label'][language] }}</a>
+                                            <a href="#{{ range['range_label'][language] | replace(" ","") | urlencode | title }}" data-placement="right">{{ range['range_curie'] }}</a>
                                         {% endif %}
                                     {% endfor %}
                                 </td>
@@ -439,14 +438,14 @@
                         <br />
                         | {%- for class in classes |sort(attribute=sortattr) %} 
                 {%- if class.rawTags['class-usage-scope'] == "main" %}
-                <a href="#{{ class.label[language] | replace(" ","") | urlencode }}">{{ class.label[language] }}</a> | {%- endif %}{%- endfor %}
+                <a href="#{{ class.label[language] | replace(" ","") | urlencode | title }}">{{ class.label[language] }}</a> | {%- endif %}{%- endfor %}
                     </p>
                     <p>
                         The main entities are supported by:
                         <br />
                         | {%- for class in classes |sort(attribute=sortattr) %} 
                 {%- if class.rawTags['class-usage-scope'] != "main" %}
-                <a href="#{{ class.label[language] | replace(" ","") | urlencode }}">{{ class.label[language] }}</a> | {%- endif %}{%- endfor %}
+                <a href="#{{ class.label[language] | replace(" ","") | urlencode | title }}">{{ class.label[language] }}</a> | {%- endif %}{%- endfor %}
                     </p>
             {% endif %}
         {% endblock %}
@@ -455,7 +454,7 @@
                     <p>
                         And supported by these datatypes:
                         <br />
-                        | {%- for datatype in datatypes |sort(attribute=sortattr) %} <a href="#{{ datatype.label[language] | replace(" ","") | urlencode }}">{{ datatype.label[language] }}</a> | {%- endfor %}
+                        | {%- for datatype in datatypes |sort(attribute=sortattr) %} <a href="#{{ datatype.label[language] | replace(" ","") | urlencode | title}}">{{ datatype.label[language] }}</a> | {%- endfor %}
                     </p>
             {% endif %}
         {% endblock %}
@@ -530,15 +529,15 @@
                 <tr>
                     <td>
                         {% if entity.scopeduri %}
-                            <div id="{{ entity.label[language] | replace(" ","") | urlencode }}">
-                                <a href="{{ entity.scopeduri }}"
+                            <div id="{{ entity.label[language] | replace(" ","") | urlencode | title }}">
+                                <a href="{{ entity.uri }}"
                                     data-toggle="tooltip"
                                     data-content="{{ entity.uri }}"
                                     data-placement="right">{{ entity.label[language] }}</a>
                             </div>
                         {% else %}
-                            <div id="{{ entity.label[language] | replace(" ","") | urlencode }}">
-                                <a href="{{ entity.uri }}"
+                            <div id="{{ entity.label[language] | replace(" ","") | urlencode | title }}">
+                                <a href="{{ entity.scopeduri }}"
                                     data-toggle="tooltip"
                                     data-content="{{ entity.uri }}"
                                     data-placement="right">{{ entity.label[language] }}</a>
@@ -580,9 +579,10 @@
                     {% if ((entity.properties | length) > 0 ) %}
                         {% for prop in entity['properties'] | sort(attribute=sortattr) %}
                             <tr>
-                                <td><a href="#{{ entity.label[language] | replace(" ","") | urlencode }}">{{ entity.label[language] }}</a></td>
+                                <td><a href="#{{ entity.label[language] | replace(' ', '') | urlencode | title }}">{{ entity.label[language] }}</a></td>
                                 <td><div class="compact-uri">{{ entity.uri }}</div></td>
-                                <td><a href="#{{ (entity.label[language] ~ '.' ~ prop.label[language]) | replace(" ","") | urlencode }}">{{ prop.label[language] }} </a></td>
+                                <!-- <td><a href="#{{ entity.label[language] | replace(' ', '') | urlencode | title }}.{{prop.label[language] | replace(' ', '') | urlencode | title }}">{{ prop.label[language] }} </a></td> -->
+                                <td><a href="#{{ (entity.label[language] ~ '.' ~ prop.label[language]) | replace(' ', '') | urlencode | title }}">{{ prop.label[language] }} </a></td>
                                 <td><div class="compact-uri">{{ prop.uri }}</div></td>
                             </tr>
                         {% endfor %}
@@ -645,25 +645,6 @@
       for (k=0;k < compactUriElems.length ; k++){
           var selem = compactUriElems[k];	
           selem.innerHTML = compactUri(selem.innerHTML.trim());
-      }
-      
-      function removePrefix(str) {
-          const index = str.indexOf(':');
-          if (index === -1) {
-              return str;
-          }
-          return str.slice(index + 1);
-      }
-
-      var noPrefix = document.getElementsByClassName("no-prefix");
-      for (k = 0; k < noPrefix.length; k++) {
-          var selem = noPrefix[k];
-          // If it's an <a> element, update its href
-            if (selem.tagName.toLowerCase() === "a" && selem.hasAttribute("href")) {
-            selem.setAttribute("href", removePrefix(decodeURIComponent(selem.getAttribute("href").trim())));
-          } else {
-            selem.innerHTML = removePrefix(decodeURIComponent(selem.innerHTML.trim()));
-          }
       }
       
     </script>

--- a/src/common/fetchers.xsl
+++ b/src/common/fetchers.xsl
@@ -482,4 +482,26 @@
             </relation>
         </xsl:sequence>
     </xsl:function>
+    <xd:doc>
+        <xd:desc>
+            Extracts documentation from a connector. The documentation can be
+            defined either at the connector level or at the target element
+            level. If both are present, the documentation from the target
+            element is preferred.
+        </xd:desc>
+        <xd:param name="connector"/>
+    </xd:doc>
+    <xsl:function name="f:getDocumentationForConnector" as="xs:string*">
+        <xsl:param name="connector"/>
+        <xsl:sequence
+        select="
+            if (boolean($connector/target/documentation/@value)) then
+                $connector/target/documentation/@value
+            else
+                if (boolean($connector/documentation/@value)) then
+                    $connector/documentation/@value
+                else
+                    ()
+            "/>
+    </xsl:function>
 </xsl:stylesheet>

--- a/src/rspec/rspec-generation.xsl
+++ b/src/rspec/rspec-generation.xsl
@@ -142,8 +142,10 @@
             },
             'range': array{
             map{
-            'uri':  f:buildURIfromLexicalQName($attribute/properties/@type),
-            'name': string($attribute/properties/@type)
+            'range_uri':  f:buildURIfromLexicalQName($attribute/properties/@type),
+            'range_puri':  f:buildURIfromLexicalQName($attribute/properties/@type),
+            'range_curie': string($attribute/properties/@type),
+            'range_label': map{'en': f:lexicalQNameToWords($attribute/properties/@type, fn:true())}
             }
             },
             'cardinality': concat($attribute/bounds/@lower, '..', $attribute/bounds/@upper),
@@ -172,7 +174,7 @@
             'uri':   f:buildURIfromLexicalQName($association/target/role/@name),
             'name':  string($association/target/role/@name),
             'label': map{'en': f:lexicalQNameToWords($association/target/role/@name, fn:true())},
-            'description': map{'en': normalize-space(f:formatDocStringForJson($association/target/documentation/@value))},
+            'description': map{'en': normalize-space(f:formatDocStringForJson(f:getDocumentationForConnector($association)))},
             'usage': map{},
             'domain': array{
             map{
@@ -180,11 +182,12 @@
             'name': string($association/source/model/@name)
             }
             },
-            'scopedrange': array{
+            'range': array{
             map{
             'range_uri':  f:buildURIfromLexicalQName($association/target/model/@name),
             'range_puri':  f:buildURIfromLexicalQName($association/target/model/@name),
-            'range_label': map{'en': string($association/target/model/@name)}
+            'range_curie': string($association/target/model/@name),
+            'range_label': map{'en': f:lexicalQNameToWords($association/target/model/@name, fn:true())}
             }
             },
             'cardinality': string($association/target/type/@multiplicity),
@@ -213,7 +216,7 @@
             'uri':   f:buildURIfromLexicalQName($dependency/target/role/@name),
             'name':  string($dependency/target/role/@name),
             'label': map{'en': f:lexicalQNameToWords($dependency/target/role/@name, fn:true())},
-            'description': map{'en': normalize-space(f:formatDocStringForJson($dependency/target/documentation/@value))},
+            'description': map{'en': normalize-space(f:formatDocStringForJson(f:getDocumentationForConnector($dependency)))},
             'usage': map{},
             'domain': array{
             map{
@@ -223,8 +226,10 @@
             },
             'range': array{
             map{
-            'uri':  f:buildURIfromLexicalQName('skos:Concept'),
-            'name': 'skos:Concept'
+            'range_uri':  f:buildURIfromLexicalQName('skos:Concept'),
+            'range_puri':  f:buildURIfromLexicalQName('skos:Concept'),
+            'range_curie': 'skos:Concept',
+            'range_label': map{'en': 'Concept'}
             }
             },
             'cardinality': string($dependency/target/type/@multiplicity),

--- a/test/unitTests/test-common/test-fetchers.xspec
+++ b/test/unitTests/test-common/test-fetchers.xspec
@@ -338,4 +338,14 @@
         </x:scenario>
     </x:scenario>
 
+    <x:scenario label="Get definition from a connector">
+        <x:call function="f:getDocumentationForConnector">
+            <x:param name="connector" 
+                href="../../testData/ePO-core-4.2.0.xml"
+                select="/xmi:XMI/xmi:Extension[1]/connectors[1]/connector[614]"/>
+        </x:call>
+        <x:expect label="definition is present"
+            select="'Reveals the winner to whom the tender award outcome is attributed.'"/>
+    </x:scenario>
+
 </x:description>


### PR DESCRIPTION
Scope of changes:
* Fixed broken internal section links for terms.
* Resolved inconsistencies in internal term link construction.
* Updated the representation of property scope for datatype properties to align with that of object properties.
* Renamed the object property scope key from `scopedrange` to `range`.
* Fixed missing property scope for datatype properties.
* Improved documentation fetching for connectors to use either the target role or connector property, while preserving existing conventions.
* Added missing property definitions for object properties (associations and dependencies).
* Corrected URL generation for datatypes.
* Fixed ReSpec data JSON generation logic in Makefile.