### PR TITLE
Remove implementation of the abandoned transformation rule and related tests

### DIFF
--- a/src/owl-restrictions.xsl
+++ b/src/owl-restrictions.xsl
@@ -44,7 +44,6 @@
             <xsl:call-template name="namespacesDeclaration"/>            
             <xsl:call-template name="ontology-header"/>
             <xsl:apply-templates/>
-            <xsl:call-template name="generalisationsWithDistinctTargetsInReasoningLayer"/>
             <xsl:call-template name="distinctAttributeNamesInReasoningLayer"/>
             <xsl:call-template name="distinctConnectorsNamesInReasoningLayer"/>
         </rdf:RDF>

--- a/src/reasoning-layer-lib/connectors-reasoning-layer.xsl
+++ b/src/reasoning-layer-lib/connectors-reasoning-layer.xsl
@@ -108,35 +108,6 @@
     </xsl:template>
 
     <xd:doc>
-        <xd:desc>Applying reasoning layer rules to generalisation connectors with distinct
-            targets</xd:desc>
-    </xd:doc>
-    <xsl:template name="generalisationsWithDistinctTargetsInReasoningLayer">
-        <xsl:variable name="generalisations"
-            select="//connector[./properties/@ea_type = 'Generalization'][not(target/@xmi:idref = preceding::connector[./properties/@ea_type = 'Generalization']/target/@xmi:idref)]"/>
-        <xsl:for-each select="$generalisations">
-            <xsl:if test="not(f:isExcludedByStatus(.))">
-            <xsl:if test="./source/model/@type = 'Class' and ./target/model/@type = 'Class'">
-                <!-- Extract prefixes for source and target -->
-                <xsl:variable name="sourcePrefix"
-                    select="fn:substring-before(./source/model/@name, ':')"/>
-                <xsl:variable name="targetPrefix"
-                    select="fn:substring-before(./target/model/@name, ':')"/>
-                <!-- Check if either the prefixes match the internal list or generateReusedConcepts is true -->
-                <xsl:if
-                    test="$generateReusedConceptsOWLrestrictions or $sourcePrefix = $includedPrefixesList">
-                    <xsl:call-template name="disjointClasses">
-                        <xsl:with-param name="generalisation" select="."/>
-                    </xsl:call-template>
-                </xsl:if>
-            </xsl:if>
-            </xsl:if>
-        </xsl:for-each>
-    </xsl:template>
-
-
-
-    <xd:doc>
         <xd:desc>Applying reasoning layer rules to connectors with distinct names [Dependency and
             Association]</xd:desc>
     </xd:doc>
@@ -641,36 +612,6 @@
         </xsl:if>
     </xsl:template>
 
-
-    <xd:doc>
-        <xd:desc>Rule R.18. Disjoint classes — in reasoning layer. Specify a disjoint classes axiom
-            for all "sibling" classes, i.e. for multiple UML Classes that have generalisation
-            connectors to the same UML Class. </xd:desc>
-        <xd:param name="generalisation"/>
-    </xd:doc>
-
-    <xsl:template name="disjointClasses">
-        <xsl:param name="generalisation"/>
-
-        <xsl:variable name="superClass" select="f:getSuperClassFromGeneralization($generalisation)"/>
-        <xsl:variable name="superClassURI" select="f:buildURIfromLexicalQName($superClass)"/>
-        <xsl:variable name="subClasses" select="f:getSubClassesFromGeneralization($generalisation)"/>
-        <xsl:if
-            test="f:getElementByIdRef($generalisation/source/@xmi:idref, root($generalisation)) and count($subClasses) > 1">
-
-            <rdf:Description>
-                <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
-                <owl:members rdf:parseType="Collection">
-                    <xsl:for-each select="$subClasses">
-                        <xsl:variable name="subClassURI" select="f:buildURIFromElement(.)"/>
-                        <rdf:Description rdf:about="{$subClassURI}"/>
-                    </xsl:for-each>
-                </owl:members>
-            </rdf:Description>
-
-        </xsl:if>
-
-    </xsl:template>
 
     <xd:doc>
         <xd:desc>This will override the common selector when applying templates</xd:desc>

--- a/test/unitTests/test-reasoning-layer-lib/test-connectors-reasoning-layer.xspec
+++ b/test/unitTests/test-reasoning-layer-lib/test-connectors-reasoning-layer.xspec
@@ -34,14 +34,6 @@
 
     </x:scenario>
     
-    <x:scenario
-        label="Test generalisationsWithDistinctTargetsInReasoningLayer">
-        <x:context href="../../testData/ePO-CM-v2.0.1-2022-04-29_test.eap.xmi"/>
-        <x:call template="generalisationsWithDistinctTargetsInReasoningLayer"/> 
-        <x:expect label="result" test="boolean(/rdf:Description/rdf:type[@rdf:resource='http://www.w3.org/2002/07/owl#AllDisjointClasses'])"/>             
-    </x:scenario>
-    
-    
     <x:scenario label="Test distinctConnectorsNamesInReasoningLayer">
         <x:context href="../../testData/ePO-CM-v2.0.1-2022-04-29_test.eap.xmi" />
         <x:call template="distinctConnectorsNamesInReasoningLayer"/> 
@@ -297,16 +289,6 @@
         <x:expect label="there is a rdf:Description" test="boolean(rdf:Description) "/>
         <x:expect label="there is a rdfs:range" test="boolean(rdf:Description/rdfs:range)"/>
         <x:expect label="range is skos:Concept" test="rdf:Description/rdfs:range/@rdf:resource = 'http://www.w3.org/2004/02/skos/core#Concept'"/>
-    </x:scenario>
-    
-    <x:scenario label="Scenario for disjoint classes">
-        <x:call template="disjointClasses">
-            <x:param name="generalisation" href="../../testData/ePO_core_with_tags.xml" select="/xmi:XMI/xmi:Extension[1]/connectors[1]/connector[43]"/>
-        </x:call>   
-        <x:expect label="there is a rdf:Description" test="boolean(rdf:Description) "/>
-        <x:expect label="there is a rdf:type with correct URI" test="boolean(rdf:Description/rdf:type) and rdf:Description/rdf:type/@rdf:resource = 'http://www.w3.org/2002/07/owl#AllDisjointClasses'"/>
-        <x:expect label="there is a 3 disjoint classes" test="count(rdf:Description/owl:members/rdf:Description)=3 "/>
-
     </x:scenario>
     
 </x:description>


### PR DESCRIPTION
The rule R.18 was implementing incorrect behaviour due to wrong assumption about UML semantics. This change removes the rule.

Subclasses are not disjoint if not explicitly marked as such with a isDisjoint generalization set property (that are not currently supported by model2owl).

_Note: This PR applies the change that has previously been merged to develop branch (see https://github.com/meaningfy-ws/model2owl/pull/13)._