### PR TITLE
Group config-parameters.xsl into sections and add a config-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ The model2owl configuration is formed from 6 files that should be in one folder:
 * umlToXsdDataTypes.xml - mapping between uml to xsd data types
 * xsdAndRdfDataTypes.xml - configure datatypes used
 
-To start just copy the default configuration files from [ePO-default-config folder](test/ePO-default-config) in your new configuration folder.
+To start just copy the default configuration files from [ePO-default-config folder](test/ePO-default-config) in your new configuration folder. Alternatively, the [config-template folder](config-template) provides the same files pre-filled with placeholder values as a blank starting point; see its [README](config-template/README.md) for the placeholders to replace.
 #### Changing config parameters
 To change the configuration in the config-parameters.xsl just simply change the value of the variable.
 Notes: 

--- a/config-template/README.md
+++ b/config-template/README.md
@@ -1,0 +1,58 @@
+# config-template — model2owl configuration template
+
+This folder is a **template** for configuring a model2owl transformation. Copy it, edit the
+values to match your ontology, and point `config-proxy.xsl` (at the repo root) at the copied
+`config-parameters.xsl` — or pass the individual files to the `make` targets via their
+override variables (e.g. `NAMESPACES_USER_XML_FILE_PATH`, `IMPORTS_XML_FILE_PATH`,
+`METADATA_JSON_PATH`). The default ePO configuration in `test/ePO-default-config/` is a
+filled-in example of the same file set.
+
+## Placeholders to replace
+
+The files come pre-filled with dummy values for demonstration purposes. These act as
+placeholders: replace each with the real value for your ontology. The table below lists
+the recurring placeholder values and what each one stands for.
+
+| Placeholder | Meaning |
+|---|---|
+| `http://example.org/ontology` | your ontology's base URI (terms become `…/ontology#YourClass`) |
+| `myprefix` | the namespace prefix of your ontology's own concepts |
+| `my-org/my-ontology`, `https://example.org/…` | your GitHub repo / project URLs |
+| `My Ontology`, `My Organisation`, `My Model` | human-readable names shown in the artefacts/report |
+
+Keep the empty (`""`) and `myprefix` entries in `namespaces.xml` aligned with
+`base-ontology-uri` in `config-parameters.xsl`.
+
+## The files
+
+| File | What it configures |
+|---|---|
+| `config-parameters.xsl` | all transformation parameters (see groups below) |
+| `metadata.json` | ontology header metadata + report/ReSpec presentation (see groups below) |
+| `namespaces.xml` | prefix → namespace-URI mappings used to build and resolve term URIs |
+| `imports.xml` | `owl:imports` added to the generated artefacts |
+| `umlToXsdDataTypes.xml` | UML attribute type → XSD datatype mapping |
+| `xsdAndRdfDataTypes.xml` | catalogue of XSD/RDF datatypes accepted in the output |
+
+## `config-parameters.xsl` parameter groups
+
+1. **Config-file references** — pointers to the sibling files above, including the overridable
+   `metadataJsonPath` param (make targets: `METADATA_JSON_PATH`).
+2. **Namespaces & URI construction** — base URIs, delimiter, `moduleReference`, derived artefact URIs.
+3. **Scope / reused-concepts filtering** — `includedPrefixesList` (which concepts are "yours") and the `generateReusedConcepts*` toggles.
+4. **Attribute → property typing** — which attribute types yield object vs datatype properties.
+5. **Accepted UML stereotypes** — per element kind.
+6. **Enumerations → SKOS** — whether enumeration items become `skos:Concept`/`ConceptScheme`.
+7. **Tags, comments, references, status & `rdfs:isDefinedBy`** — tag keys for comments/notes/usage/status, ReSpec reference labels, status filtering, and the two `annotate…WithOntology` flags that switch `rdfs:isDefinedBy` on/off (OWL and SHACL).
+8. **Output toggles & misc** — object/realisation generation, SHACL PlainLiteral handling, supported UML versions, issued date.
+
+## `metadata.json` field groups
+
+1. **Ontology identity & versioning** — titles/labels/descriptions, version, status, dates, preferred namespace, publisher, license.
+2. **People** — `contributors`, `owners`.
+3. **Links & resources** — see-also/changelog/feedback/repository links, `dependencies`, `localBiblio`, `projectLocalResources`.
+4. **Convention report** — the `conventionReport*` fields shown on the convention report.
+5. **Doc / ReSpec presentation** — `documentConfig`, `navigation`, `openGithubIssue`, `logo`.
+
+All metadata fields are optional: a field left blank or removed is simply omitted from
+the output (it does not fail the build).

--- a/config-template/config-parameters.xsl
+++ b/config-template/config-parameters.xsl
@@ -10,69 +10,59 @@
 
     <xd:doc scope="stylesheet">
         <xd:desc>
-            <xd:p><xd:b>Created on:</xd:b> Mar 22, 2020</xd:p>
-            <xd:p><xd:b>Author:</xd:b> lps</xd:p>
-            <xd:p>This module defines project level variables and parameters.
-                Parameters are grouped by purpose into the numbered sections
-                below.</xd:p>
+            <xd:p>Project-level configuration for a model2owl transformation.</xd:p>
+            <xd:p>This is a TEMPLATE: copy this folder, edit the values, and point
+                <xd:i>config-proxy.xsl</xd:i> at it (or pass its files to the make
+                targets). Parameters are grouped by purpose (see the numbered
+                sections below and the accompanying README.md). Values written as
+                <xd:i>myprefix:*</xd:i> or <xd:i>http://example.org/*</xd:i> are
+                placeholders to replace with your own ontology's prefix and URIs.</xd:p>
         </xd:desc>
     </xd:doc>
 
     <!-- ===================================================================== -->
     <!-- 1. Config-file references (the sibling files in this config folder)    -->
     <!-- ===================================================================== -->
-    <!-- a set of prefix-baseURI definitions -->
     <xsl:variable name="namespacePrefixes" select="fn:doc('namespaces.xml')"/>
-    <!-- a mapping between UML atomic types to XSD datatypes  -->
     <xsl:variable name="umlDataTypesMapping" select="fn:doc('umlToXsdDataTypes.xml')"/>
-    <!-- XSD datatypes that conform to OWL2 requirements   -->
     <xsl:variable name="xsdAndRdfDataTypes" select="fn:doc('xsdAndRdfDataTypes.xml')"/>
     <!-- JSON metadata configuration. The path is overridable via the
-         `metadataJsonPath` stylesheet parameter; the default `metadata.json` is
-         resolved relative to this config file, preserving the original behaviour
-         (and following whichever config `config-proxy.xsl` imports). -->
+         `metadataJsonPath` stylesheet parameter (make targets: METADATA_JSON_PATH);
+         the default `metadata.json` is resolved relative to this config file. -->
     <xsl:param name="metadataJsonPath" select="'metadata.json'"/>
     <xsl:variable name="metadataJson" select="fn:json-doc($metadataJsonPath)"/>
 
     <!-- ===================================================================== -->
     <!-- 2. Namespaces & URI construction                                      -->
     <!-- ===================================================================== -->
-    <!--    set default namespace interpretation for lexical Qnames that are not prefix:localSegment or :localSegment. If this
-    is set to true localSegment will transform to :localSegment-->
+    <!-- If true, a bare localSegment (no prefix) is interpreted as :localSegment
+         (i.e. in the default/empty-prefix namespace). -->
     <xsl:variable name="defaultNamespaceInterpretation" select="fn:true()"/>
-
-    <!-- Ontology base URI, configure as necessary. Do not use a trailing local delimiter
-        like in the namespace definition-->
-    <!--<xsl:variable name="base-uri" select="'http://publications.europa.eu/ontology/ePO'"/>-->
-    <xsl:variable name="base-ontology-uri" select="'http://data.europa.eu/a4g/ontology'"/>
-    <xsl:variable name="base-shape-uri" select="'http://data.europa.eu/a4g/data-shape'"/>
+    <!-- Base URIs of YOUR ontology. No trailing delimiter (the delimiter below is added). -->
+    <xsl:variable name="base-ontology-uri" select="'http://example.org/ontology'"/>
+    <xsl:variable name="base-shape-uri" select="'http://example.org/data-shape'"/>
     <xsl:variable name="base-restriction-uri" select="$base-ontology-uri"/>
-
-    <!-- when a delimiter is missing in the base URI of a namespace, use this default value-->
+    <!-- Delimiter appended to a base URI when it has none (e.g. '#' or '/'). -->
     <xsl:variable name="defaultDelimiter" select="'#'"/>
-
-    <!-- suffix for URIs of sh:NodeShape instances in the SHACL artefact -->
+    <!-- Suffix for sh:NodeShape URIs in the SHACL artefact. -->
     <xsl:variable name="nodeShapeURIsuffix" select="'Shape'"/>
-
     <!-- Short id of this module; also used in the artefact URIs (…#<moduleReference>). -->
     <xsl:variable name="moduleReference" select="'core'"/>
-
-    <!--    Shapes Module URI-->
     <xsl:variable name="shapeArtefactURI"
         select="fn:concat($base-shape-uri,$defaultDelimiter, $moduleReference, '-shape')"/>
-    <!--    Restrictions Module URI-->
     <xsl:variable name="restrictionsArtefactURI"
         select="fn:concat($base-restriction-uri, $defaultDelimiter, $moduleReference, '-restriction')"/>
-    <!--    Core Module URI-->
     <xsl:variable name="coreArtefactURI"
         select="fn:concat($base-ontology-uri, $defaultDelimiter, $moduleReference)"/>
 
     <!-- ===================================================================== -->
     <!-- 3. Scope / reused-concepts filtering                                  -->
     <!-- ===================================================================== -->
-    <!--    Generate reused classes, attributes and connectors. Concepts with these prefixes will be included in the generated artefacts. -->
-    <xsl:variable name="includedPrefixesList" select="('epo', 'epo-acc', 'epo-cat', 'epo-con', 'epo-ful', 'epo-inv', 'epo-not', 'epo-ord', 'epo-sub', 'epo-eva', 'epo-awa', 'epo-req', 'epo-qua', 'epo-pay')"/>
-    <!-- This set of variables controls the generation of reused concepts within artifacts. -->
+    <!-- The namespace prefix(es) of YOUR ontology's own concepts. Concepts with
+         these prefixes are treated as "main" and generated; others are reused
+         concepts. Use '' (empty string) if your model's class names carry no prefix. -->
+    <xsl:variable name="includedPrefixesList" select="('myprefix')"/>
+    <!-- Whether reused (out-of-scope-prefix) concepts are still emitted, per artefact. -->
     <xsl:variable name="generateReusedConceptsSHACL" select="fn:true()"/>
     <xsl:variable name="generateReusedConceptsOWLcore" select="fn:true()"/>
     <xsl:variable name="generateReusedConceptsOWLrestrictions" select="fn:true()"/>
@@ -82,11 +72,12 @@
     <!-- ===================================================================== -->
     <!-- 4. Attribute -> property typing                                       -->
     <!-- ===================================================================== -->
-    <!-- types of elements and names for attribute types that are acceptable to produce object properties -->
+    <!-- Attribute types that still yield an object property. Add your project's
+         identifier datatype(s), e.g. ('myprefix:Identifier', 'rdfs:Literal'). -->
     <xsl:variable name="acceptableTypesForObjectProperties"
-        select="('epo:Identifier', 'rdfs:Literal')"/>
-    <!--    the type of attributes which takes values from a controlled list-->
-    <xsl:variable name="controlledListType" select="'epo:Code'"/>
+        select="('rdfs:Literal')"/>
+    <!-- The attribute type whose values come from a controlled list / code list. -->
+    <xsl:variable name="controlledListType" select="'myprefix:Code'"/>
 
     <!-- ===================================================================== -->
     <!-- 5. Accepted UML stereotypes (per element kind)                        -->
@@ -106,88 +97,64 @@
     <!-- ===================================================================== -->
     <!-- 6. Enumerations -> SKOS                                                -->
     <!-- ===================================================================== -->
-    <!--    This variable controls whether the enumeration items are transformed into skos concepts or ignored-->
+    <!-- Transform enumeration items into skos:Concept / skos:ConceptScheme? -->
     <xsl:variable name="enableGenerationOfSkosConcept" select="fn:false()"/>
-    <!--    This variable controls whether the enumerations are transformed into skos schemes or ignored-->
     <xsl:variable name="enableGenerationOfConceptSchemes" select="fn:false()"/>
-    <!--    Property used for constraint level for enumerations-->
-    <xsl:variable name="cvConstraintLevelProperty" select="'epo:constraintLevel'"/>
+    <!-- Tag carrying the constraint level for enumerations. -->
+    <xsl:variable name="cvConstraintLevelProperty" select="'myprefix:constraintLevel'"/>
 
     <!-- ===================================================================== -->
     <!-- 7. Tags, comments, references, status & rdfs:isDefinedBy              -->
     <!-- ===================================================================== -->
     <!-- 7a. Comments / notes -->
-    <!--    This set of variables controls generation of comments and how they will generate in the output -->
     <xsl:variable name="commentsGeneration" select="fn:true()"/>
     <xsl:variable name="commentProperty" select="'skos:editorialNote'"/>
-    <!-- Tag name/key that is used to describe a usage note of a class or property-->
     <xsl:variable name="usageNoteTagName" select="'skos:note'"/>
-    <!-- Tag name/key that is used as custom label for terms in the ReSpec documentation-->
     <xsl:variable name="customTermLabelTagName" select="'skos:prefLabel'"/>
 
     <!-- 7b. Tag keys & reference labels -->
-    <!-- Tag name/key that is used to indicate if a property is mandatory or
-         optional. If the tag is missing then cardinality will be used to
-         determine if a property is mandatory or optional-->
+    <!-- Tag indicating whether a property is mandatory/optional (else cardinality is used). -->
     <xsl:variable name="mandatoryStatusTagName" select="'cfg:usage'"/>
-    <!-- Tag name/key that is used to provide reference links/reuse information for a class or property-->
+    <!-- Tag providing reference/reuse links for a class or property. -->
     <xsl:variable name="referenceTagName" select="'dcterms:references'"/>
-    <!-- Label that will be used in the ReSpec docs to describe values of `referenceTagName` for properties -->
+    <!-- ReSpec labels for the reference/reuse information. -->
     <xsl:variable name="propertyReferenceRespecLabel" select="'Reuse'"/>
-    <!-- Label that will be used in the ReSpec docs to describe values of `referenceTagName` for classes -->
     <xsl:variable name="classReferenceRespecLabel" select="'Reference'"/>
-    <!-- A flag to control whether references/reuse information is shown in the ReSpec docs -->
     <xsl:variable name="showReferencesInRespec" select="fn:true()"/>
-    <!--    Tag names/keys that are excluded from output -->
+    <!-- Tag names excluded from the output. -->
     <xsl:variable name="excludedTagNamesList" select="($statusProperty, $cvConstraintLevelProperty)"/>
 
     <!-- 7c. Status filtering -->
-    <!-- Variables for status filtering:
-     - The property used to indicate the status
-     - A list of valid statuses
-     - A list of statuses to be excluded from the output
-     - The default status value interpretation for elements without a status set -->
-    <xsl:variable name="statusProperty" select="'epo:status'"/>
+    <xsl:variable name="statusProperty" select="'myprefix:status'"/>
     <xsl:variable name="validStatusesList" select="('proposed', 'approved', 'implemented')"/>
     <xsl:variable name="excludedElementStatusesList" select="('proposed', 'approved')"/>
     <xsl:variable name="unspecifiedStatusInterpretation" select="'implemented'"/>
 
     <!-- 7d. rdfs:isDefinedBy annotation -->
-    <!--    If true, this will annotate all OWL concepts defined in the current ontology
-    with the name of the core ontology using rdfs:isDefinedBy.-->
+    <!-- Annotate every concept defined in this ontology with rdfs:isDefinedBy
+         pointing at the ontology IRI. One flag for the OWL artefacts, one for SHACL.
+         Set to fn:false() to suppress (see transformation rules T.08 / T.09). -->
     <xsl:variable name="annotateDefinedConceptsWithOntology" select="fn:true()"/>
-    <!-- If true, this option will annotate all SHACL concepts in the shapes
-    artefact with the ontology IRI defined therein, using rdfs:isDefinedBy. -->
     <xsl:variable name="annotateShaclConceptsWithOntology" select="fn:true()"/>
 
     <!-- ===================================================================== -->
     <!-- 8. Output toggles & misc                                              -->
     <!-- ===================================================================== -->
-    <!-- This variable control if Object and Realisation are generated -->
+    <!-- Generate UML Objects and Realisation connectors. -->
     <xsl:variable name="generateObjectsAndRealisations" select="fn:false()"/>
-
-    <!-- If enabled then any occurence of rdf:PlainLiteral datatype will be
-    replaced in a SHACL shape. A list of the two string datatypes will be used
-    instead: (xsd:string, rdf:langString).
-    -->
+    <!-- Replace rdf:PlainLiteral in SHACL shapes with (xsd:string, rdf:langString). -->
     <xsl:variable name="translatePlainLiteralToStringTypesInSHACL" select="fn:true()"/>
-
-    <!--Allowed characters for a normalized string-->
+    <!-- Allowed characters for a normalized string. -->
     <xsl:variable name="allowedStrings" select="'^[\w\d-_:]+$'"/>
-
-    <!-- URIs list of UML versions supported by model2owl -->
+    <!-- UML versions (XMI namespace URIs) accepted by model2owl. -->
     <xsl:variable name="supportedUmlVersions"
         select="('http://www.omg.org/spec/UML/20131001',
             'https://www.omg.org/spec/UML/20131001',
             'http://www.omg.org/spec/UML/20161101',
             'https://www.omg.org/spec/UML/20161101'
         )"/>
-
-    <!-- Date used for dct:issued property in the RDF artefacts and ReSpec
-    documentation. Defaults to the currrent date.
-    A fixed date can be set as follows:
-    select="xs:date('2024-01-01')"
-    -->
+    <!-- Date for dct:issued. Defaults to the current date; for a fixed date use
+         select="xs:date('2024-01-01')". -->
     <xsl:variable name="issuedDate" select="format-date(current-date(),'[Y0001]-[M01]-[D01]')"/>
 
 </xsl:stylesheet>

--- a/config-template/imports.xml
+++ b/config-template/imports.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<imports xmlns="http://publications.europa.eu/ns/">
+    <!-- owl:imports added to the generated artefacts. List the external ontologies
+         your model reuses. Leave a section empty to import nothing there.
+         Example (uncomment and adapt):
+           <import uri="http://purl.org/dc/terms/"/>
+           <import uri="http://www.w3.org/2004/02/skos/core#"/>
+    -->
+    <!-- affects all three artefacts -->
+    <all></all>
+    <!-- affects core artefact -->
+    <core></core>
+    <!-- affects restrictions artefact -->
+    <restrictions></restrictions>
+    <!-- affects SHACL artefact -->
+    <shacl></shacl>
+</imports>

--- a/config-template/metadata.json
+++ b/config-template/metadata.json
@@ -1,0 +1,132 @@
+{
+    "metadata": {
+        "title": "My Ontology",
+        "status": "Draft",
+        "versionInfo": "1.0.0",
+        "priorVersion": "",
+        "incompatibleWith": "",
+        "createdDate": "2024-01-01",
+        "ontologyTitleCore": "My Ontology core",
+        "ontologyTitleRestrictions": "My Ontology restrictions",
+        "ontologyTitleShapes": "My Ontology shapes",
+        "ontologyLabelCore": "My Ontology — core",
+        "ontologyLabelRestrictions": "My Ontology — restrictions",
+        "ontologyLabelShapes": "My Ontology — shapes",
+        "ontologyDescriptionCore": "Definitions of the core concepts of My Ontology (excludes the restrictions).",
+        "ontologyDescriptionRestrictions": "Restrictions and inference-related axioms of My Ontology (excludes the definitions).",
+        "ontologyDescriptionShapes": "Generic SHACL data-shape specifications for My Ontology.",
+        "preferredNamespaceUri": "http://example.org/ontology#",
+        "preferredNamespacePrefix": "myprefix",
+        "publisher": "https://example.org/publisher",
+        "license": "CC BY 4.0",
+
+        "contributors": [
+            {
+                "first_name": "Alice",
+                "last_name": "Example",
+                "email": "alice@example.org",
+                "role": "E",
+                "affiliation": {
+                    "name": "ACME Labs",
+                    "website": "https://acme.example"
+                }
+            },
+            {
+                "first_name": "John",
+                "last_name": "Smith",
+                "email": "john@example.org",
+                "role": "A",
+                "affiliation": {
+                    "name": "ACME Labs",
+                    "website": "https://acme.example"
+                }
+            }
+        ],
+        "owners": [
+            {
+                "name": "ACME",
+                "website": "https://acme.example"
+            },
+            {
+                "name": "Tom White"
+            }
+        ],
+
+        "seeAlsoResources": [
+            "https://example.org/related-resource"
+        ],
+        "changelogUrl": "https://github.com/my-org/my-ontology/releases",
+        "feedbackUrl": "https://github.com/my-org/my-ontology/issues",
+        "repositoryUrl": "https://github.com/my-org/my-ontology",
+        "github": "my-org/my-ontology",
+        "dependencies": [],
+        "localBiblio": {
+            "W3ID": {
+                "href": "https://w3id.org/",
+                "title": "Permanent Identifiers for the Web",
+                "publisher": "W3C Permanent Identifier Community Group"
+            }
+        },
+        "projectLocalResources": [
+            {
+                "name": "OWL core file",
+                "path": "owl_ontology/my_ontology.rdf"
+            },
+            {
+                "name": "OWL restrictions file",
+                "path": "owl_ontology/my_ontology_restrictions.rdf"
+            },
+            {
+                "name": "SHACL shapes file (TTL)",
+                "path": "shacl_shapes/my_ontology_shapes.ttl"
+            },
+            {
+                "name": "JSON-LD context file",
+                "path": "jsonld_context/my_ontology_context.jsonld"
+            },
+            {
+                "name": "UML XMI model file",
+                "path": "xmi_conceptual_model/my_ontology.xml"
+            }
+        ],
+
+        "conventionReportAuthor": "My Organisation",
+        "conventionReportAuthorLocation": "City, Country",
+        "conventionReportAuthorWebsite": "https://example.org",
+        "conventionReportCopyrightText": "My Organisation, 2024",
+        "conventionReportUMLModelName": "My Model",
+
+        "documentConfig": {
+            "editorDocumentRoot": "."
+        },
+        "navigation": {
+            "next": "",
+            "prev": "",
+            "self": "https://example.org/my-ontology/releases/1.0.0/"
+        },
+        "openGithubIssue": {
+            "columnLabel": "Feedback",
+            "buttonLabel": "Report an issue or share feedback"
+        },
+        "logo": {
+            "path": "assets/img/logo.png",
+            "link": "https://example.org"
+        }
+    },
+    "customMetadata": {
+        "metadataSectionProperties": [
+            {
+                "key": "Related documentation",
+                "data": [
+                    {
+                        "value": "Doc1",
+                        "href": "https://example.com/doc1"
+                    },
+                    {
+                        "value": "Doc2"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/config-template/namespaces.xml
+++ b/config-template/namespaces.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prefixes xmlns="http://publications.europa.eu/ns/">
+    <!-- YOUR ontology's namespace, bound to your project prefix `myprefix`. Keep it
+         aligned with base-ontology-uri in config-parameters.xsl, and list this prefix
+         in includedPrefixesList so your own concepts are treated as "main". -->
+    <prefix name="myprefix" value="http://example.org/ontology#"/>
+    <!-- Fallback for UNPREFIXED terms. The empty ("") prefix is the default namespace
+         where model2owl mints URIs for model element names written without a prefix.
+         Define it next to your prefix above, like the commented line below. It MUST be
+         defined if your input model does NOT use prefixes for its terms (classes,
+         attributes, association roles, etc.); in that case also set includedPrefixesList
+         to ('') so those unprefixed concepts count as "main". -->
+    <!-- <prefix name="" value="http://example.org/ontology#"/> -->
+
+    <!-- Standard / commonly reused namespaces. Add any further vocabularies your
+         model reuses (e.g. a domain ontology). -->
+    <prefix name="adms" value="http://www.w3.org/ns/adms#"/>
+    <prefix name="dct" value="http://purl.org/dc/terms/"/>
+    <prefix name="dcterms" value="http://purl.org/dc/terms/"/>
+    <prefix name="foaf" value="http://xmlns.com/foaf/0.1/"/>
+    <prefix name="geosparql" value="http://www.opengis.net/ont/geosparql#"/>
+    <prefix name="legal" value="http://www.w3.org/ns/legal-entity#"/>
+    <prefix name="locn" value="http://www.w3.org/ns/locn#"/>
+    <prefix name="org" value="http://www.w3.org/ns/org#"/>
+    <prefix name="owl" value="http://www.w3.org/2002/07/owl#"/>
+    <prefix name="person" value="http://www.w3.org/ns/person#"/>
+    <prefix name="rdf" value="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+    <prefix name="rdfs" value="http://www.w3.org/2000/01/rdf-schema#"/>
+    <prefix name="schema" value="http://schema.org/"/>
+    <prefix name="skos" value="http://www.w3.org/2004/02/skos/core#"/>
+    <prefix name="time" value="http://www.w3.org/2006/time#"/>
+    <prefix name="xml" value="http://www.w3.org/XML/1998/namespace"/>
+    <prefix name="xsd" value="http://www.w3.org/2001/XMLSchema#"/>
+
+    <!-- Namespace of the configuration/usage tags (mandatoryStatusTagName = cfg:usage). -->
+    <prefix name="cfg" value="http://www.example.org#"/>
+</prefixes>

--- a/config-template/umlToXsdDataTypes.xml
+++ b/config-template/umlToXsdDataTypes.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mappings xmlns="http://publications.europa.eu/ns/">
+
+<!-- XSD datatypes -->
+    <!-- no mapping necessary as they are already defined in xsdAndRdfDataTypes.xml as the valid set of OWL2 datatypes in -->
+<!-- end of section -->
+
+<!-- UML primitive datatypes (capitalised forms) per docs "Mapping of UML primitive
+     types to XSD datatypes" (rule:datatype-core, tab:type-mapping) plus the UML 2.5
+     standard primitives (String, Boolean, UnlimitedNatural, Real).
+     NOTE: capitalised names that collide with one of your own datatype local names
+     (e.g. Boolean, Integer, Date, DateTime, Time, Numeric, Text — see the custom
+     domain-type mappings at the bottom) are intentionally NOT added here, so a bare
+     occurrence of such a name keeps its project-specific semantics rather than being
+     rewritten to an XSD primitive. -->
+    <mapping><from qname="Float"/>            <to qname="xsd:float"/></mapping>
+    <mapping><from qname="Double"/>           <to qname="xsd:double"/></mapping>
+    <mapping><from qname="Int"/>              <to qname="xsd:int"/></mapping>
+    <mapping><from qname="Char"/>             <to qname="xsd:string"/></mapping>
+    <mapping><from qname="Character"/>        <to qname="xsd:string"/></mapping>
+    <mapping><from qname="String"/>           <to qname="xsd:string"/></mapping>
+    <mapping><from qname="Byte"/>             <to qname="xsd:byte"/></mapping>
+    <mapping><from qname="Short"/>            <to qname="xsd:short"/></mapping>
+    <mapping><from qname="Long"/>             <to qname="xsd:long"/></mapping>
+    <mapping><from qname="Decimal"/>          <to qname="xsd:decimal"/></mapping>
+    <mapping><from qname="Real"/>             <to qname="xsd:float"/></mapping>
+    <mapping><from qname="UnlimitedNatural"/> <to qname="xsd:nonNegativeInteger"/></mapping>
+<!-- end of section -->
+
+<!-- UML primitive datatypes (lowercase forms as emitted by Enterprise Architect
+     in properties/@type). Mirrors the capitalised set above. -->
+    <mapping><from qname="boolean"/>          <to qname="xsd:boolean"/></mapping>
+    <mapping><from qname="float"/>            <to qname="xsd:float"/></mapping>
+    <mapping><from qname="double"/>           <to qname="xsd:double"/></mapping>
+    <mapping><from qname="integer"/>          <to qname="xsd:integer"/></mapping>
+    <mapping><from qname="int"/>              <to qname="xsd:int"/></mapping>
+    <mapping><from qname="char"/>             <to qname="xsd:string"/></mapping>
+    <mapping><from qname="character"/>        <to qname="xsd:string"/></mapping>
+    <mapping><from qname="string"/>           <to qname="xsd:string"/></mapping>
+    <mapping><from qname="byte"/>             <to qname="xsd:byte"/></mapping>
+    <mapping><from qname="short"/>            <to qname="xsd:short"/></mapping>
+    <mapping><from qname="long"/>             <to qname="xsd:long"/></mapping>
+    <mapping><from qname="decimal"/>          <to qname="xsd:decimal"/></mapping>
+    <mapping><from qname="real"/>             <to qname="xsd:float"/></mapping>
+    <mapping><from qname="date"/>             <to qname="xsd:date"/></mapping>
+    <mapping><from qname="dateTime"/>         <to qname="xsd:dateTime"/></mapping>
+    <mapping><from qname="datetime"/>         <to qname="xsd:dateTime"/></mapping>
+    <mapping><from qname="time"/>             <to qname="xsd:time"/></mapping>
+    <mapping><from qname="unsignedInt"/>      <to qname="xsd:unsignedInt"/></mapping>
+    <mapping><from qname="unsignedShort"/>    <to qname="xsd:unsignedShort"/></mapping>
+    <mapping><from qname="unsignedLong"/>     <to qname="xsd:unsignedLong"/></mapping>
+    <mapping><from qname="unsignedByte"/>     <to qname="xsd:unsignedByte"/></mapping>
+<!-- end of section -->
+
+<!-- Custom domain-type mappings (EXAMPLE).
+     Map your ontology's own datatype names to an XSD/RDFS type here. The entries
+     below are an illustrative example (from the eProcurement Ontology, using the
+     `epo:` prefix) — replace them with your project's custom datatypes, or remove
+     this section if you have none. A name mapped here is intentionally NOT also
+     listed among the UML primitive mappings above, so it keeps these
+     project-specific semantics. -->
+    <mapping>
+        <from  qname="epo:Indicator"/>
+        <to  qname="xsd:boolean"/>
+    </mapping>
+    <mapping>
+        <from  qname="epo:Date"/>
+        <to  qname="xsd:date"/>
+    </mapping>
+    <mapping>
+        <from  qname="epo:DateTime"/>
+        <to  qname="xsd:dateTime"/>
+    </mapping>
+    <mapping>
+        <from  qname="epo:Numeric"/>
+        <to  qname="xsd:decimal"/>
+    </mapping>
+    <mapping>
+        <from  qname="epo:Text"/>
+        <to  qname="rdfs:Literal"/>
+    </mapping>
+    <mapping>
+        <from  qname="epo:Time"/>
+        <to  qname="xsd:time"/>
+    </mapping>
+    <mapping>
+        <from  qname="epo:URI"/>
+        <to  qname="xsd:anyURI"/>
+    </mapping>
+    <mapping>
+        <from  qname="epo:Integer"/>
+        <to  qname="xsd:integer"/>
+    </mapping>
+    <mapping>
+        <from  qname="epo:Code"/>
+        <to  qname="skos:Concept"/>
+    </mapping>
+<!-- end of section -->
+
+</mappings>

--- a/config-template/xsdAndRdfDataTypes.xml
+++ b/config-template/xsdAndRdfDataTypes.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<datatypes xmlns="http://publications.europa.eu/ns/">
+    <datatype namespace="xsd" qname="xsd:anyURI"/>
+    <datatype namespace="xsd" qname="xsd:base64Binary"/>
+    <datatype namespace="xsd" qname="xsd:boolean"/>
+    <datatype namespace="xsd" qname="xsd:byte"/>
+    <datatype namespace="xsd" qname="xsd:date"/>
+    <datatype namespace="xsd" qname="xsd:dateTime"/>
+    <datatype namespace="xsd" qname="xsd:dateTimeStamp"/>
+    <datatype namespace="xsd" qname="xsd:time"/>
+    <datatype namespace="xsd" qname="xsd:decimal"/>
+    <datatype namespace="xsd" qname="xsd:double"/>
+    <datatype namespace="xsd" qname="xsd:float"/>
+    <datatype namespace="xsd" qname="xsd:hexBinary"/>
+    <datatype namespace="xsd" qname="xsd:int"/>
+    <datatype namespace="xsd" qname="xsd:integer"/>
+    <datatype namespace="xsd" qname="xsd:language"/>
+    <datatype namespace="xsd" qname="xsd:long"/>
+    <datatype namespace="xsd" qname="xsd:Name"/>
+    <datatype namespace="xsd" qname="xsd:NCName"/>
+    <datatype namespace="xsd" qname="xsd:NMTOKEN"/>
+    <datatype namespace="xsd" qname="xsd:negativeInteger"/>
+    <datatype namespace="xsd" qname="xsd:nonNegativeInteger"/>
+    <datatype namespace="xsd" qname="xsd:nonPositiveInteger"/>
+    <datatype namespace="xsd" qname="xsd:normalizedString"/>
+    <datatype namespace="xsd" qname="xsd:positiveInteger"/>
+    <datatype namespace="xsd" qname="xsd:short"/>
+    <datatype namespace="xsd" qname="xsd:string"/>
+    <datatype namespace="xsd" qname="xsd:token"/>
+    <datatype namespace="xsd" qname="xsd:unsignedByte"/>
+    <datatype namespace="xsd" qname="xsd:unsignedInt"/>
+    <datatype namespace="xsd" qname="xsd:unsignedLong"/>
+    <datatype namespace="xsd" qname="xsd:unsignedShort"/>
+    
+    <datatype namespace="rdf" qname="rdf:HTML"/>
+    <datatype namespace="rdf" qname="rdf:XMLLiteral"/>
+    <datatype namespace="rdf" qname="rdf:langString"/>
+    
+    <datatype namespace="rdf" qname="rdf:PlainLiteral"/>
+
+    
+</datatypes>


### PR DESCRIPTION
## What

Two changes to the configuration layer:

1. **Reorganise `test/ePO-default-config/config-parameters.xsl`** into eight
   purpose-grouped, banner-commented sections (config-file references; namespaces &
   URI construction; scope/reused-concepts filtering; attribute→property typing;
   accepted UML stereotypes; enumerations→SKOS; tags/comments/references/status &
   `rdfs:isDefinedBy`; output toggles & misc).

2. **Add a top-level `config-template/`** — a reusable, placeholder-valued starting
   config (`config-parameters.xsl` + `namespaces.xml`, `imports.xml`, `metadata.json`,
   `umlToXsdDataTypes.xml`, `xsdAndRdfDataTypes.xml`, and a `README.md`), adapted from the
   model2owl-boilerplate template. The template's `config-parameters.xsl` exposes the
   overridable `metadataJsonPath` param to match this repo's engine. The project `README.md`
   Configuration section now points at it as an alternative starting point.

## Safety / behaviour

The reorg is a **pure re-layout**: the parameter set and every value are unchanged.
Verified two ways:
- a `name`/`select` diff of old vs new — **58 vars/params in, 58 out, identical**;
- a Saxon compile of the full import chain (config → namespaces/uml/xsd docs + metadata.json),
  confirming all cross-section references resolve to the correct ePO values.

`config-template/` is intentionally **not wired** into any build — `config-proxy.xsl` still
imports `test/ePO-default-config/…`, and no Makefile/CI/test glob picks up the new dir, so its
placeholder values can't be transformed or tested.

## Notes

- No Makefile changes (the public interface is untouched).
- No editorial/convention-message text changed, so no ted-model2owl-docs sync is required.