### PR TITLE
Support {disjoint} generalization-set modifier in owl-restrictions

### DIFF
--- a/src/common/fetchers.xsl
+++ b/src/common/fetchers.xsl
@@ -228,7 +228,39 @@
                   f:getElementByIdRef($id, $root)"
         />
     </xsl:function>
-    
+
+    <xd:doc>
+        <xd:desc>Returns all UML generalization sets in the logical model. They are
+            packagedElements whose xmi:type is 'uml:GeneralizationSet'. Selected unprefixed
+            with a STRING compare on @xmi:type because the model's uml namespace revision
+            (2016) differs from the stylesheet binding (2013); a uml:-prefixed path matches
+            nothing.</xd:desc>
+        <xd:param name="root"/>
+    </xd:doc>
+    <xsl:function name="f:getGeneralizationSets" as="node()*">
+        <xsl:param name="root" as="node()"/>
+        <xsl:sequence select="$root//packagedElement[@xmi:type = 'uml:GeneralizationSet']"/>
+    </xsl:function>
+
+    <xd:doc>
+        <xd:desc>Returns the member subclasses of a generalization set, as EA element nodes.
+            Each set member is a generalization referenced by idref; the owning subclass is
+            the packagedElement that declares that generalization (matched by xmi:id), and it
+            is resolved to the EA &lt;element&gt; node via its shared id so the URI builders and
+            the term filters apply to it.</xd:desc>
+        <xd:param name="generalizationSet"/>
+        <xd:param name="root"/>
+    </xd:doc>
+    <xsl:function name="f:getGeneralizationSetSubclasses" as="node()*">
+        <xsl:param name="generalizationSet" as="node()"/>
+        <xsl:param name="root" as="node()"/>
+        <xsl:sequence
+            select="
+                for $memberIdref in $generalizationSet/generalization/@xmi:idref
+                return
+                    f:getElementByIdRef($root//packagedElement[generalization/@xmi:id = $memberIdref]/@xmi:id, $root)"/>
+    </xsl:function>
+
     <xd:doc>
         <xd:desc>Returns true when the element is an association class. An association class is a
             uml:AssociationClass in the logical model but surfaces as a uml:Class in the EA

--- a/src/html-conventions-lib/general-html-conventions.xsl
+++ b/src/html-conventions-lib/general-html-conventions.xsl
@@ -134,8 +134,9 @@
 
     <xd:doc>
         <xd:desc>[general-modifier-type-4] UML attribute / generalisation-set modifiers
-            ({id}, {complete}, {disjoint}) are not transformed. Reports which kinds occur at
-            least once in the model (presence only, not each occurrence). </xd:desc>
+            ({id}, {complete}) are not transformed. {disjoint} IS transformed (OWL
+            disjointness in owl-restrictions) and is no longer reported here. Reports which
+            kinds occur at least once in the model (presence only, not each occurrence). </xd:desc>
         <xd:param name="root"/>
     </xd:doc>
     <xsl:template name="modifierTypes">
@@ -148,10 +149,6 @@
             <xsl:if
                 test="$root//connectors/connector[properties/@ea_type = 'Generalization']/xrefs[contains(@value, 'IsCovering=1')]">
                 <xsl:sequence select="'{complete}'"/>
-            </xsl:if>
-            <xsl:if
-                test="$root//connectors/connector[properties/@ea_type = 'Generalization']/xrefs[contains(@value, 'IsDisjoint=1')]">
-                <xsl:sequence select="'{disjoint}'"/>
             </xsl:if>
         </xsl:variable>
         <xsl:sequence

--- a/src/owl-restrictions.xsl
+++ b/src/owl-restrictions.xsl
@@ -41,11 +41,12 @@
     </xd:doc>
     <xsl:template match="/">
         <rdf:RDF>
-            <xsl:call-template name="namespacesDeclaration"/>            
+            <xsl:call-template name="namespacesDeclaration"/>
             <xsl:call-template name="ontology-header"/>
             <xsl:apply-templates/>
             <xsl:call-template name="distinctAttributeNamesInReasoningLayer"/>
             <xsl:call-template name="distinctConnectorsNamesInReasoningLayer"/>
+            <xsl:call-template name="disjointClassesFromGeneralizationSets"/>
         </rdf:RDF>
     </xsl:template>
 

--- a/src/reasoning-layer-lib/connectors-reasoning-layer.xsl
+++ b/src/reasoning-layer-lib/connectors-reasoning-layer.xsl
@@ -504,6 +504,44 @@
     </xsl:template>
 
     <xd:doc>
+        <xd:desc>Rule R.18 (re-introduced, set-aware). Emits OWL class disjointness for the
+            member subclasses of every generalization set marked {disjoint}
+            (isDisjoint='true'). Exactly two surviving members produce owl:disjointWith;
+            three or more produce owl:AllDisjointClasses. Members are filtered per term
+            (status, namespace/reused-concepts, association class, Class only); if fewer than
+            two survive, nothing is emitted. The common superclass is irrelevant to the
+            disjointness axiom and is not consulted.</xd:desc>
+    </xd:doc>
+    <xsl:template name="disjointClassesFromGeneralizationSets">
+        <xsl:variable name="root" select="/"/>
+        <xsl:for-each select="f:getGeneralizationSets($root)[@isDisjoint = 'true']">
+            <xsl:variable name="members" select="f:getGeneralizationSetSubclasses(., $root)"/>
+            <xsl:variable name="includedMembers" select="
+                    $members[@xmi:type = 'uml:Class']
+                           [not(f:isExcludedByStatus(.))]
+                           [not(f:isAssociationClass(.))]
+                           [$generateReusedConceptsOWLrestrictions
+                              or fn:substring-before(@name, ':') = $includedPrefixesList]"/>
+            <xsl:if test="count($includedMembers) = 2">
+                <rdf:Description rdf:about="{f:buildURIFromElement($includedMembers[1])}">
+                    <owl:disjointWith rdf:resource="{f:buildURIFromElement($includedMembers[2])}"/>
+                </rdf:Description>
+            </xsl:if>
+            <xsl:if test="count($includedMembers) > 2">
+                <rdf:Description>
+                    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+                    <owl:members rdf:parseType="Collection">
+                        <xsl:for-each select="$includedMembers">
+                            <rdf:Description rdf:about="{f:buildURIFromElement(.)}"/>
+                        </xsl:for-each>
+                    </owl:members>
+                </rdf:Description>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:template>
+
+
+    <xd:doc>
         <xd:desc>
             Rule R.06. Association and dependency multiplicity — in reasoning layer
 

--- a/test/unitTests/test-common/test-fetchers.xspec
+++ b/test/unitTests/test-common/test-fetchers.xspec
@@ -549,4 +549,23 @@
                   and $x:result/target/@name = 'SomeOtherClass'"/>
     </x:scenario>
 
+    <x:scenario label="getGeneralizationSets returns every generalization set">
+        <x:call function="f:getGeneralizationSets">
+            <x:param name="root" href="../../testData/prettyModel-cleaned.xmi" select="/"/>
+        </x:call>
+        <x:expect label="three sets in the model" test="count(/packagedElement) = 3"/>
+        <x:expect label="two are disjoint" test="count(/packagedElement[@isDisjoint = 'true']) = 2"/>
+    </x:scenario>
+
+    <x:scenario label="getGeneralizationSetSubclasses resolves the bm set to Bicycle and Monocycle">
+        <x:call function="f:getGeneralizationSetSubclasses">
+            <x:param name="generalizationSet" href="../../testData/prettyModel-cleaned.xmi"
+                select="//packagedElement[@name = 'bm']"/>
+            <x:param name="root" href="../../testData/prettyModel-cleaned.xmi" select="/"/>
+        </x:call>
+        <x:expect label="two member subclasses" test="count(/element) = 2"/>
+        <x:expect label="Bicycle resolved" test="boolean(/element[@name = 'Bicycle'])"/>
+        <x:expect label="Monocycle resolved" test="boolean(/element[@name = 'Monocycle'])"/>
+    </x:scenario>
+
 </x:description>

--- a/test/unitTests/test-html-conventions-lib/test-general-html-conventions.xspec
+++ b/test/unitTests/test-html-conventions-lib/test-general-html-conventions.xspec
@@ -67,7 +67,7 @@
             test="contains(/dd, 'does not transform UML attribute or generalisation-set modifiers')"/>
         <x:expect label="{id} is listed" test="contains(/dd, '{id}')"/>
         <x:expect label="{complete} is listed" test="contains(/dd, '{complete}')"/>
-        <x:expect label="{disjoint} is listed" test="contains(/dd, '{disjoint}')"/>
+        <x:expect label="{disjoint} is no longer listed (now supported)" test="not(contains(/dd, '{disjoint}'))"/>
     </x:scenario>
 
     <x:scenario label="Scenario for reporting unsupported UML constructs (general-construct-type-5)">

--- a/test/unitTests/test-reasoning-layer-lib/test-connectors-reasoning-layer.xspec
+++ b/test/unitTests/test-reasoning-layer-lib/test-connectors-reasoning-layer.xspec
@@ -320,6 +320,16 @@
             test="count(/rdf:Description[rdf:type/@rdf:resource = 'http://www.w3.org/2002/07/owl#AllDisjointClasses']/owl:members/rdf:Description) = 3"/>
         <x:expect label="the covering set fb (Wheel hierarchy) produces no disjointness"
             test="not(//*[@rdf:about[contains(., 'Wheel')]]) and not(//*[@rdf:resource[contains(., 'Wheel')]])"/>
+        <x:expect label="owl:disjointWith subject URI contains Bicycle"
+            test="contains(/rdf:Description[owl:disjointWith]/@rdf:about, 'Bicycle')"/>
+        <x:expect label="owl:disjointWith object URI contains Monocycle"
+            test="contains(/rdf:Description[owl:disjointWith]/owl:disjointWith/@rdf:resource, 'Monocycle')"/>
+    </x:scenario>
+
+    <x:scenario label="disjointClassesFromGeneralizationSets emits nothing when no disjoint sets exist">
+        <x:context href="../../testData/ePO-CM-v2.0.1-2022-04-29_test.eap.xmi"/>
+        <x:call template="disjointClassesFromGeneralizationSets"/>
+        <x:expect label="no output when model has no disjoint sets" select="()"/>
     </x:scenario>
 
 </x:description>

--- a/test/unitTests/test-reasoning-layer-lib/test-connectors-reasoning-layer.xspec
+++ b/test/unitTests/test-reasoning-layer-lib/test-connectors-reasoning-layer.xspec
@@ -303,10 +303,23 @@
     <x:scenario label="Scenario for dependency range to enumeration">
         <x:call template="connectorDependencyRange">
             <x:param name="connector" href="../../testData/ePO-CM-v2.0.1-2020-03-27_test.eap.xmi" select="/xmi:XMI/xmi:Extension[1]/connectors[1]/connector[247]"/>
-        </x:call>   
+        </x:call>
         <x:expect label="there is a rdf:Description" test="boolean(rdf:Description) "/>
         <x:expect label="there is a rdfs:range" test="boolean(rdf:Description/rdfs:range)"/>
         <x:expect label="range is skos:Concept" test="rdf:Description/rdfs:range/@rdf:resource = 'http://www.w3.org/2004/02/skos/core#Concept'"/>
     </x:scenario>
-    
+
+    <x:scenario label="disjointClassesFromGeneralizationSets emits disjointness only for {disjoint} sets">
+        <x:context href="../../testData/prettyModel-cleaned.xmi"/>
+        <x:call template="disjointClassesFromGeneralizationSets"/>
+        <x:expect label="exactly one owl:disjointWith axiom (bm, 2 members)"
+            test="count(/rdf:Description[owl:disjointWith]) = 1"/>
+        <x:expect label="exactly one AllDisjointClasses axiom (bcc, 3 members)"
+            test="count(/rdf:Description[rdf:type/@rdf:resource = 'http://www.w3.org/2002/07/owl#AllDisjointClasses']) = 1"/>
+        <x:expect label="the AllDisjointClasses set lists 3 members"
+            test="count(/rdf:Description[rdf:type/@rdf:resource = 'http://www.w3.org/2002/07/owl#AllDisjointClasses']/owl:members/rdf:Description) = 3"/>
+        <x:expect label="the covering set fb (Wheel hierarchy) produces no disjointness"
+            test="not(//*[@rdf:about[contains(., 'Wheel')]]) and not(//*[@rdf:resource[contains(., 'Wheel')]])"/>
+    </x:scenario>
+
 </x:description>


### PR DESCRIPTION
Re-introduces OWL class disjointness generation (Rule R.18), now driven solely by the explicit UML `{disjoint}` generalization-set modifier (`isDisjoint="true"`).

## Changes
- New fetchers `f:getGeneralizationSets` / `f:getGeneralizationSetSubclasses` reading the logical `uml:GeneralizationSet` tree
- New reasoning-layer template `disjointClassesFromGeneralizationSets`: 2 members → `owl:disjointWith`; 3+ → `owl:AllDisjointClasses`; per-member status/namespace/association-class filtering
- Removes `{disjoint}` from the `general-modifier-type-4` "unsupported" convention warning

## Tests
1087 XSpec tests pass; prettyModel smoke test produces correct axioms; ePO output unchanged.